### PR TITLE
Add image build automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,52 @@
+version: 2.1
+jobs:
+  build_synapse:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            IMAGE_NAME=raidennetwork/raiden-services-bundle \
+            DOCKER_TAG=${CIRCLE_TAG:-nightly}-synapse; \
+            docker build -t ${IMAGE_NAME}:${DOCKER_TAG} build/synapse ; \
+            echo "$DEVOPS_DOCKERHUB_TOKEN" | docker login -u brainbotdevops --password-stdin ; \
+            docker push ${IMAGE_NAME}:${DOCKER_TAG}
+  build_db:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            IMAGE_NAME=raidennetwork/raiden-services-bundle \
+            DOCKER_TAG=${CIRCLE_TAG:-nightly}-db; \
+            docker build -t ${IMAGE_NAME}:${DOCKER_TAG} build/db ; \
+            echo "$DEVOPS_DOCKERHUB_TOKEN" | docker login -u brainbotdevops --password-stdin ; \
+            docker push ${IMAGE_NAME}:${DOCKER_TAG}
+  build_well_known:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            IMAGE_NAME=raidennetwork/raiden-services-bundle \
+            DOCKER_TAG=${CIRCLE_TAG:-nightly}-well_known_server; \
+            docker build -t ${IMAGE_NAME}:${DOCKER_TAG} build/well_known_server ; \
+            echo "$DEVOPS_DOCKERHUB_TOKEN" | docker login -u brainbotdevops --password-stdin ; \
+            docker push ${IMAGE_NAME}:${DOCKER_TAG}
+
+workflows:
+  version: 2
+  build_images:
+    jobs:
+      - build_synapse
+      - build_db
+      - build_well_known

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,10 @@ jobs:
       - run:
           name: Build Docker image
           command: |
+            BUILD_ARGS="SYNAPSE_VERSION=v1.4.1" \
             IMAGE_NAME=raidennetwork/raiden-services-bundle \
             DOCKER_TAG=${CIRCLE_TAG:-nightly}-synapse; \
-            docker build -t ${IMAGE_NAME}:${DOCKER_TAG} build/synapse ; \
+            docker build --build-arg ${BUILD_ARGS} -t ${IMAGE_NAME}:${DOCKER_TAG} build/synapse ; \
             echo "$DEVOPS_DOCKERHUB_TOKEN" | docker login -u brainbotdevops --password-stdin ; \
             docker push ${IMAGE_NAME}:${DOCKER_TAG}
   build_db:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Build Docker image
           command: |
-            BUILD_ARGS="SYNAPSE_VERSION=v1.4.1" \
+            BUILD_ARGS="SYNAPSE_VERSION=v1.5.1" \
             IMAGE_NAME=raidennetwork/raiden-services-bundle \
             DOCKER_TAG=${CIRCLE_TAG:-nightly}-synapse; \
             docker build --build-arg ${BUILD_ARGS} -t ${IMAGE_NAME}:${DOCKER_TAG} build/synapse ; \

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## What is this repository
 
-This repository contains the documentation and configuration necessary to run a 
+This repository contains the documentation and configuration necessary to run a
 Raiden Transport Matrix server.
 
-**Current release:** [2019.10.1](https://github.com/raiden-network/raiden-transport/tree/2019.10.1)
+**Current release:** [2019.10.1](https://github.com/raiden-network/raiden-service-bundle/tree/2019.10.1)
 
 ## Table of Contents
 
@@ -20,15 +20,15 @@ Raiden Transport Matrix server.
 
 ## Overview
 
-The Raiden Network uses a federation of [Matrix](https://matrix.org) servers as it's transport 
-layer. To ensure reliability, availability and neutrality it is desirable that those servers are 
+The Raiden Network uses a federation of [Matrix](https://matrix.org) servers as it's transport
+layer. To ensure reliability, availability and neutrality it is desirable that those servers are
 being operated by multiple independent entities.
 
-Therefore we provide this repository which allows easy setup of such a transport server. 
-It uses docker and docker-compose for easy installation and upgrades. 
+Therefore we provide this repository which allows easy setup of such a transport server.
+It uses docker and docker-compose for easy installation and upgrades.
 
-Currently only this single-server configuration is supported, in the future we may also 
-provide configurations with services split among multiple servers. 
+Currently only this single-server configuration is supported, in the future we may also
+provide configurations with services split among multiple servers.
 
 ### Used software
 
@@ -53,14 +53,14 @@ provide configurations with services split among multiple servers.
           |
 +---------v---------+
 |                   |        Federation to other
-|      Traefik    +-+----->  Raiden Matrix servers 
-|                 | |       
+|      Traefik    +-+----->  Raiden Matrix servers
+|                 | |
 +---------+-------+-+---------+
           |       |           |
 +---------v-------v-+   +-----v----------------+
 |                   |   |                      |
 |      Synapse      |   |  Raiden Pathfinding  |
-|                   |   |                      | 
+|                   |   |                      |
 +---------+---------+   +----------------------+
           |
 +---------v---------+
@@ -71,26 +71,26 @@ provide configurations with services split among multiple servers.
 ```
 
 
-We use Traefik as a reverse proxy and also utilize it's capability of automatically provisiong 
+We use Traefik as a reverse proxy and also utilize it's capability of automatically provisiong
 Let's Encrypt TLS certificates.
 
 The Synapse server is being run in the so-called split worker configuration which increases throughput.
 
-The database stores the message data. Since the transport layer is considered ephemeral in Raiden it 
-is not necessary to arrange for backups of the database data. 
+The database stores the message data. Since the transport layer is considered ephemeral in Raiden it
+is not necessary to arrange for backups of the database data.
 
 ### Network
 
 After a successful deployment the following ports will be in use:
 
 - 80 - HTTP
-  - Redirects to HTTPS 
+  - Redirects to HTTPS
   - Let's Encrypt HTTP challenge for certificate provisioning
-- 443 - HTTPS 
+- 443 - HTTPS
   - Synapse web and API client access
   - Synapse Server-to-Server federation
   - Raiden Pathfinding Server (on subdomain `pfs.$SERVER_NAME`)
-  - Metrics export (IP restricted, see below) 
+  - Metrics export (IP restricted, see below)
 
 ## Requirements
 
@@ -102,7 +102,7 @@ Minimum recommended for a production setup:
 -  8 Cores
 - 50 GiB SSD
 
-Note: The default Postgres configuration assumes 16GiB of system RAM   
+Note: The default Postgres configuration assumes 16GiB of system RAM
 
 ### Software
 
@@ -111,15 +111,15 @@ Note: The default Postgres configuration assumes 16GiB of system RAM
 
 ### Other
 
-- A domain (or subdomain) for exclusive use by this server   
+- A domain (or subdomain) for exclusive use by this server
 
 ## Installation
 
 ### Preparation
 
 1. Provision a server that meets the [hardware](#hardware) and [software](#software) requirements listed above.
-1. Ensure a domain (or subdomain) is available 
-  
+1. Ensure a domain (or subdomain) is available
+
    Examples:
    - raidentransport.somecompany.tld
    - raidentransport-somecompany.tld
@@ -131,16 +131,16 @@ Note: The default Postgres configuration assumes 16GiB of system RAM
 
 ### Installing
 
-1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-transport/tree/2019.10.1)
+1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2019.10.1)
    to a suitable location on the server:
-   
+
    ```shell
-   git clone -b 2019.10.1 https://github.com/raiden-network/raiden-transport.git
+   git clone -b 2019.10.1 https://github.com/raiden-network/raiden-service-bundle.git
    ```
 1. Copy `.env.template` to `.env` and modify the values to fit your setup (see inline comments for details)
-   - We would appreciate it if you allow us access to the monitoring interfaces 
+   - We would appreciate it if you allow us access to the monitoring interfaces
      (to do that uncomment the default values of the `CIDR_ALLOW_METRICS` and `CIDR_ALLOW_PROXY` settings).
-   - We also recommend that you provide your own monitoring. The setup of which is currently out of scope of this document. 
+   - We also recommend that you provide your own monitoring. The setup of which is currently out of scope of this document.
 1. Run `docker-compose build` to build the containers
 1. Run `docker-compose up -d` to start all services
    - The services are configured to automatically restart in case of a crash or reboot
@@ -148,12 +148,12 @@ Note: The default Postgres configuration assumes 16GiB of system RAM
 
 ### Submit
 
-1. [Create an issue](https://github.com/raiden-network/raiden-transport/issues/new) and submit the 
-   domain / URL of the newly deployed server for inclusion in the list of known servers.    
+1. [Create an issue](https://github.com/raiden-network/raiden-service-bundle/issues/new) and submit the
+   domain / URL of the newly deployed server for inclusion in the list of known servers.
 
 ## Upgrades
 
-To upgrade to a new release please check the [changelog](#changelog) for any necessary 
+To upgrade to a new release please check the [changelog](#changelog) for any necessary
 configuration changes and then run the following commands:
 
 ```shell
@@ -172,8 +172,8 @@ docker-compose up -d
 
 ### Protection against Spam / (D)DoS attacks
 
-There is currently only some protection against Spam and / or DDoS attacks. 
-This will be addressed in future updates. 
+There is currently only some protection against Spam and / or DDoS attacks.
+This will be addressed in future updates.
 
 ### Known servers
 
@@ -185,7 +185,7 @@ We intend to change this in the future to use a decentralized scheme (for exampl
 
 ## Contact / Troubleshooting
 
-To report issues or request help with the setup please [open an issue](https://github.com/raiden-network/raiden-transport/issues/new)
+To report issues or request help with the setup please [open an issue](https://github.com/raiden-network/raiden-service-bundle/issues/new)
 or contact us via email at contact@raiden.nework.
 
 
@@ -201,7 +201,7 @@ or contact us via email at contact@raiden.nework.
     - Port 8448 is no longer needed
 - 2018-12-19 - `2018.12.0` - **Maintenance release**
   - purger.py restart improvements
-- 2018-10-19 - `2018.10.0` - **Maintenence release** 
+- 2018-10-19 - `2018.10.0` - **Maintenence release**
   - Add new servers to known list
   - Upgrade Synapse to 0.33.7
   - Automatically purge historic state and restart service once a day, removing the need for an external cron service

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Raiden Transport Matrix server.
 
 ## Overview
 
-The Raiden Network uses a federation of [Matrix](https://matrix.org) servers as it's transport
+The Raiden Network uses a federation of [Matrix](https://matrix.org) servers as its transport
 layer. To ensure reliability, availability and neutrality it is desirable that those servers are
 being operated by multiple independent entities.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ being operated by multiple independent entities.
 Therefore we provide this repository which allows easy setup of such a transport server.
 It uses docker and docker-compose for easy installation and upgrades.
 
-Currently only this single-server configuration is supported, in the future we may also
+Currently only this single-server configuration is supported; in the future we may also
 provide configurations with services split among multiple servers.
 
 ### Used software
@@ -37,7 +37,7 @@ provide configurations with services split among multiple servers.
 - Synapse
 - Postgres
 - Traefik
-- Raiden Services
+- Raiden Services (Pathfinding, Monitoring)
 
 ### Structure
 
@@ -47,31 +47,31 @@ provide configurations with services split among multiple servers.
 |                   |
 |   Raiden clients  |
 |                   |
-+---------+---------+
-          |
-==========|==========
-          |
-+---------v---------+
-|                   |        Federation to other
-|      Traefik    +-+----->  Raiden Matrix servers
++---+-----------+---+
+    |matrix://  |pfs://
+====|===========|====
+    |           |
++---v-----------v---+                       Federation to
+|                 +-+-------------------->  other Raiden
+|      Traefik    | |                       Matrix servers
 |                 | |
 +---------+-------+-+---------+
           |       |           |
-+---------v-------v-+   +-----v----------------+
-|                   |   |                      |
-|      Synapse      |   |  Raiden Pathfinding  |
-|                   |   |                      |
-+---------+---------+   +----------------------+
-          |
-+---------v---------+
-|                   |
-|     Postgres      |
-|                   |
-+-------------------+
++---------v-------v-+   +-----v----------------+ +---------------------+
+|                   |   |                      | |                     |
+|      Synapse      |   |  Raiden Pathfinding  | |  Raiden Monitoring  |
+|                   |   |                      | |                     |
++---------+---------+   +-------------------+--+ +-+-------------------+
+          |                                 |      |
++---------v---------+                     +-v- - - v -+
+|                   |                     |
+|     Postgres      |                        ETH_RPC  |
+|                   |                     |
++-------------------+                     + - - - - - +
 ```
 
 
-We use Traefik as a reverse proxy and also utilize it's capability of automatically provisiong
+We use Traefik as a reverse proxy and also utilize its capability of automatically provisioning
 Let's Encrypt TLS certificates.
 
 The Synapse server is being run in the so-called split worker configuration which increases throughput.
@@ -141,10 +141,15 @@ Note: The default Postgres configuration assumes 16GiB of system RAM
    - We would appreciate it if you allow us access to the monitoring interfaces
      (to do that uncomment the default values of the `CIDR_ALLOW_METRICS` and `CIDR_ALLOW_PROXY` settings).
    - We also recommend that you provide your own monitoring. The setup of which is currently out of scope of this document.
+1. Make sure, that the account, configured in `KEYSTORE_FILE`, has enough funding to register as a service operator.
 1. Run `docker-compose build` to build the containers
 1. Run `docker-compose up -d` to start all services
    - The services are configured to automatically restart in case of a crash or reboot
 1. Verify the service is up by opening the domain in a browser. You should see a page with the Matrix logo.
+
+### Troubleshooting
+After starting, you can run `docker-compose ps` -- if any services are not in `Up`, `Up (healthy)` or `Exit 0` state, you should check the respective logs for configuration errors.
+Note: some services might need a few minutes to become healthy.
 
 ### Submit
 
@@ -159,7 +164,6 @@ configuration changes and then run the following commands:
 ```shell
 git fetch origin --tags
 git reset --hard <new-release-tag>
-docker-compose build --pull
 docker-compose pull
 docker-compose up -d
 ```
@@ -190,7 +194,10 @@ or contact us via email at contact@raiden.nework.
 
 
 ## Changelog
-
+- WIP - `WIP` - **Upgrade release**
+  - Upgrade Synapse to v1.4.1
+  - Use `stable` release from https://github.com/raiden-network/raiden-services
+  - Use version tagged public images instead of building locally.
 - 2019-10-07 - `2019.10.1` - **Upgrade release**
   - Upgrade https://github.com/raiden-network/raiden-services image to `v0.4.0`
 - 2019-10-02 - `2019.10.0` - **Upgrade release**

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ or contact us via email at contact@raiden.nework.
 
 ## Changelog
 - WIP - `WIP` - **Upgrade release**
-  - Upgrade Synapse to v1.4.1
+  - Upgrade Synapse to v1.5.1
   - Use `stable` release from https://github.com/raiden-network/raiden-services
   - Use version tagged public images instead of building locally.
 - 2019-10-07 - `2019.10.1` - **Upgrade release**

--- a/build/synapse/Dockerfile
+++ b/build/synapse/Dockerfile
@@ -3,17 +3,14 @@ LABEL maintainer="Raiden Network Team <contact@raiden.network>"
 
 ARG SYNAPSE_VERSION
 
-RUN cd /opt && \
-        wget https://github.com/matrix-org/synapse/archive/develop.zip && \
-        unzip develop.zip && \
-        python -m venv /synapse-venv && \
-        /synapse-venv/bin/pip install --upgrade pip && \
-        /synapse-venv/bin/pip install -e synapse-develop[postgres]
+RUN \
+    python -m venv /synapse-venv && \
+    /synapse-venv/bin/pip install "matrix-synapse[postgres]==${SYNAPSE_VERSION}"
 
 RUN /synapse-venv/bin/pip install psycopg2 coincurve pycryptodome
 
 # Temporary patch until raiden-network/raiden#4634 is resolved
-RUN sed -i -E 's/^MAX_DISPLAYNAME_LEN = 100$/MAX_DISPLAYNAME_LEN = 200/' /opt/synapse-develop/synapse/handlers/profile.py
+RUN sed -i -E 's/^MAX_DISPLAYNAME_LEN = 100$/MAX_DISPLAYNAME_LEN = 200/' /synapse-venv/lib/python3.7/site-packages/synapse/handlers/profile.py
 
 COPY eth_auth_provider.py /synapse-venv/lib/python3.7/site-packages/
 COPY synapse-entrypoint.sh /bin/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 
 x-defaults: &defaults
-  image: raidennetwork/raiden-services:v0.4.0
+  image: raidennetwork/raiden-services:stable
   env_file: .env
   volumes:
     - ${DATA_DIR:-./data}/state:/state
@@ -75,11 +75,7 @@ services:
 
 # raiden-transport containers
   synapse:
-    build:
-      context: build/synapse
-      args:
-        SYNAPSE_VERSION: v1.3.1
-    image: raiden-network/synapse
+    image: raidennetwork/raiden-services-bundle:nightly-synapse
     restart: always
     volumes:
       - ./config/synapse:/config
@@ -103,7 +99,7 @@ services:
       - "purge_restart_container=true"
 
   synchrotron:
-    image: raiden-network/synapse
+    image: raidennetwork/raiden-services-bundle:nightly-synapse
     restart: always
     volumes:
       - ./config/synapse:/config
@@ -124,7 +120,7 @@ services:
       - "traefik.backend.loadbalancer.stickiness=true"
 
 #  federation_reader:
-#    image: raiden-network/synapse
+#    image: raidennetwork/raiden-services-bundle:nightly-synapse
 #    restart: always
 #    volumes:
 #      - ./config/synapse:/config
@@ -145,7 +141,7 @@ services:
 #      - "traefik.frontend.rule=Host:${SERVER_NAME}; PathPrefix: /_matrix/federation/v1/{type:(event|state|state_ids|backfill|get_missing_events|publicRooms)}"
 #
 #  federation_sender:
-#    image: raiden-network/synapse
+#    image: raidennetwork/raiden-services-bundle:nightly-synapse
 #    restart: always
 #    volumes:
 #      - ./config/synapse:/config
@@ -160,7 +156,7 @@ services:
 #      disable: true
 #
   client_reader:
-    image: raiden-network/synapse
+    image: raidennetwork/raiden-services-bundle:nightly-synapse
     restart: always
     volumes:
       - ./config/synapse:/config
@@ -180,7 +176,7 @@ services:
       - "traefik.backend.loadbalancer.stickiness=true"
 
   user_dir:
-    image: raiden-network/synapse
+    image: raidennetwork/raiden-services-bundle:nightly-synapse
     restart: always
     volumes:
       - ./config/synapse:/config
@@ -201,7 +197,7 @@ services:
       - "traefik.backend.loadbalancer.stickiness=true"
 
   event_creator:
-    image: raiden-network/synapse
+    image: raidennetwork/raiden-services-bundle:nightly-synapse
     restart: always
     volumes:
       - ./config/synapse:/config
@@ -221,8 +217,7 @@ services:
       - "traefik.frontend.rule=Host:${SERVER_NAME}; PathPrefix: /_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/send, /_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/{action:(join|invite|leave|ban|unban|kick)}, /_matrix/client/{version:(api/v1|r0|unstable)}/join/, /_matrix/client/{version:(api/v1|r0|unstable)}/profile/"
       - "traefik.backend.loadbalancer.stickiness=true"
   db:
-    build:
-      context: build/db
+    image: raidennetwork/raiden-services-bundle:nightly-db
     restart: always
     volumes:
       - ${DATA_DIR:-./data}/db:/var/lib/postgresql/data
@@ -231,8 +226,7 @@ services:
 
   # Serves the .well-known/matrix/server file
   well_known_server:
-    build:
-      context: build/well_known_server
+    image: raidennetwork/raiden-services-bundle:nightly-well_known_server
     restart: always
     volumes:
       - ${DATA_DIR:-./data}/well-known:/data


### PR DESCRIPTION
This fixes #36 

- The images for `build/*` now reside at https://hub.docker.com/r/raidennetwork/raiden-services-bundle (note the extra `s` in `services` -- follow up: #49)
- The `docker-compose.yml` recipe now uses the `image:` keyword instead of doing a `build:` from local files.
- Building the docker images now happens on [CircleCI](https://circleci.com/gh/raiden-network/raiden-service-bundle)
- The versioning for `docker build` tags the images as: `raidennetwork/raiden-services-bundle:{$TAG}`, where `${TAG}` is of the form `${RELEASE_GIT_TAG}_${SERVICE_NAME}` or `nightly_${SERVICE_NAME}`. (follow-up #50)

Other changes:
- The  [raiden-services](https://github.com/raiden-network/raiden-services) container are now using the `stable` tag.
- Synapse is now at version `v1.4.1`
- `README.md` was updated to give a more comprehensive overview, and up-to-date installation/upgrade instructions.

Follow ups:
- #49 (see above)
- Version bumps should happen tool assisted #50 