### PR TITLE
Manual registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Note: The default Postgres configuration assumes 16GiB of system RAM
      (to do that uncomment the default values of the `CIDR_ALLOW_METRICS` and `CIDR_ALLOW_PROXY` settings).
    - We also recommend that you provide your own monitoring. The setup of which is currently out of scope of this document.
 1. Make sure, that the account, configured in `KEYSTORE_FILE`, has enough funding to register as a service operator.
-1. Run `docker-compose build` to build the containers
+1. If you haven't done so before, run `./register-service-provider.sh` (it uses configuration values from `.env`).
 1. Run `docker-compose up -d` to start all services
    - The services are configured to automatically restart in case of a crash or reboot
 1. Verify the service is up by opening the domain in a browser. You should see a page with the Matrix logo.
@@ -151,7 +151,7 @@ Note: The default Postgres configuration assumes 16GiB of system RAM
 After starting, you can run `docker-compose ps` -- if any services are not in `Up`, `Up (healthy)` or `Exit 0` state, you should check the respective logs for configuration errors.
 Note: some services might need a few minutes to become healthy.
 
-### Submit
+### Submit a Transport Server to the federation
 
 1. [Create an issue](https://github.com/raiden-network/raiden-service-bundle/issues/new) and submit the
    domain / URL of the newly deployed server for inclusion in the list of known servers.
@@ -198,6 +198,8 @@ or contact us via email at contact@raiden.nework.
   - Upgrade Synapse to v1.5.1
   - Use `stable` release from https://github.com/raiden-network/raiden-services
   - Use version tagged public images instead of building locally.
+  - Make all bundled software versions easier to maintain (`BUILD_VERSIONS` & `docker-compose.yml::x-versions`).
+  - Removed auto registration, added interactive registration script (`./register-service-provider.sh`).
 - 2019-10-07 - `2019.10.1` - **Upgrade release**
   - Upgrade https://github.com/raiden-network/raiden-services image to `v0.4.0`
 - 2019-10-02 - `2019.10.0` - **Upgrade release**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,16 +78,6 @@ services:
         condition: service_healthy
     healthcheck:
       disable: true
-  # This registers the service and stops afterwards
-  registration:
-    <<: *services-defaults
-    command: ["python3", "-m", "raiden_libs.register_service"]
-    environment:
-      - RDN_REGISTRY_LOG_LEVEL=${LOG_LEVEL}
-      - RDN_REGISTRY_KEYSTORE_FILE=/keystore/${KEYSTORE_FILE}
-      - RDN_REGISTRY_PASSWORD=${PASSWORD}
-      - RDN_REGISTRY_SERVICE_URL=${SERVER_NAME}
-      - RDN_REGISTRY_ETH_RPC=${ETH_RPC}
 
 # raiden-transport containers
   synapse:

--- a/register-service-provider.sh
+++ b/register-service-provider.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+. .env
+
+IMAGE=$(grep "raidennetwork/raiden-services:" docker-compose.yml|cut -d ':' -f2-|xargs)
+
+CMD="python3 -m raiden_libs.register_service"
+
+docker run --rm -it \
+  -v ${DATA_DIR:-./data}/state:/state \
+  -v ${DATA_DIR:-./data}/keystore:/keystore \
+  -e RDN_REGISTRY_LOG_LEVEL=${LOG_LEVEL} \
+  -e RDN_REGISTRY_KEYSTORE_FILE=/keystore/${KEYSTORE_FILE} \
+  -e RDN_REGISTRY_PASSWORD=${PASSWORD} \
+  -e RDN_REGISTRY_SERVICE_URL=${SERVER_NAME} \
+  -e RDN_REGISTRY_ETH_RPC=${ETH_RPC} \
+  --env-file .env \
+  ${IMAGE} \
+  ${CMD}


### PR DESCRIPTION
Fixes #51 
Instead of running the `registration` service automatically on
    `docker-compose up..`, there is now a dedicated shell script to register
    the service provider: `register-service-provider.sh`.
    
The `registration` service is removed from `docker-compose.yml`.
    
The script makes use of the same environment definition (`.env`) as
    `docker-compose.yml`, therefore any configuration overhead is avoided.
    
Yet, it is possible to also run the registration from a different
    machine, if necessary.
