### PR TITLE
Release 2019.11.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 2018.10.0
+current_version = 2019.10.1
 commit = True
 tag = True
 tag_name = {new_version}
 
 [bumpversion:file:README.md]
-parse = [^`](?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+parse = [^`](?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)[^`]
 serialize = {major}.{minor}.{patch}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2019.10.1
+current_version = 2019.11.0
 commit = True
 tag = True
 tag_name = {new_version}
@@ -7,3 +7,4 @@ tag_name = {new_version}
 [bumpversion:file:README.md]
 parse = [^`](?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)[^`]
 serialize = {major}.{minor}.{patch}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Changelog
-- WIP - `WIP` - **Upgrade release**
+- 2019-11-20 - `2019.11.0` - **Upgrade release**
   - Upgrade Synapse to v1.5.1
   - Use `stable` release from https://github.com/raiden-network/raiden-services
   - Use version tagged public images instead of building locally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+## Changelog
+- WIP - `WIP` - **Upgrade release**
+  - Upgrade Synapse to v1.5.1
+  - Use `stable` release from https://github.com/raiden-network/raiden-services
+  - Use version tagged public images instead of building locally.
+  - Make all bundled software versions easier to maintain (`BUILD_VERSIONS` & `docker-compose.yml::x-versions`).
+  - Removed auto registration, added interactive registration script (`./register-service-provider.sh`).
+- 2019-10-07 - `2019.10.1` - **Upgrade release**
+  - Upgrade https://github.com/raiden-network/raiden-services image to `v0.4.0`
+- 2019-10-02 - `2019.10.0` - **Upgrade release**
+  - Add https://github.com/raiden-network/raiden-services services to the bundle
+  - Upgrade Synapse to v1.3.1
+  - Tune Postgres default parameters
+  - Merge federation access under regular HTTPS port (443)
+    - Port 8448 is no longer needed
+- 2018-12-19 - `2018.12.0` - **Maintenance release**
+  - purger.py restart improvements
+- 2018-10-19 - `2018.10.0` - **Maintenence release**
+  - Add new servers to known list
+  - Upgrade Synapse to 0.33.7
+  - Automatically purge historic state and restart service once a day, removing the need for an external cron service
+  - Updated minimum docker and docker-compose version requirements
+- 2018-08-09 - `2018.8.1` - **Initial public release**
+- 2018-08-02 - `2018.8.0` - **Initial version**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository contains the documentation and configuration necessary to run a
 Raiden Transport Matrix server.
 
-**Current release:** [2019.10.1](https://github.com/raiden-network/raiden-service-bundle/tree/2019.10.1)
+**Current release:** [2019.11.0](https://github.com/raiden-network/raiden-service-bundle/tree/2019.11.0)
 
 ## Table of Contents
 
@@ -131,11 +131,11 @@ Note: The default Postgres configuration assumes 16GiB of system RAM
 
 ### Installing
 
-1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2019.10.1)
+1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2019.11.0)
    to a suitable location on the server:
 
    ```shell
-   git clone -b 2019.10.1 https://github.com/raiden-network/raiden-service-bundle.git
+   git clone -b 2019.11.0 https://github.com/raiden-network/raiden-service-bundle.git
    ```
 1. Copy `.env.template` to `.env` and modify the values to fit your setup (see inline comments for details)
    - We would appreciate it if you allow us access to the monitoring interfaces

--- a/README.md
+++ b/README.md
@@ -194,30 +194,7 @@ or contact us via email at contact@raiden.nework.
 
 
 ## Changelog
-- WIP - `WIP` - **Upgrade release**
-  - Upgrade Synapse to v1.5.1
-  - Use `stable` release from https://github.com/raiden-network/raiden-services
-  - Use version tagged public images instead of building locally.
-  - Make all bundled software versions easier to maintain (`BUILD_VERSIONS` & `docker-compose.yml::x-versions`).
-  - Removed auto registration, added interactive registration script (`./register-service-provider.sh`).
-- 2019-10-07 - `2019.10.1` - **Upgrade release**
-  - Upgrade https://github.com/raiden-network/raiden-services image to `v0.4.0`
-- 2019-10-02 - `2019.10.0` - **Upgrade release**
-  - Add https://github.com/raiden-network/raiden-services services to the bundle
-  - Upgrade Synapse to v1.3.1
-  - Tune Postgres default parameters
-  - Merge federation access under regular HTTPS port (443)
-    - Port 8448 is no longer needed
-- 2018-12-19 - `2018.12.0` - **Maintenance release**
-  - purger.py restart improvements
-- 2018-10-19 - `2018.10.0` - **Maintenence release**
-  - Add new servers to known list
-  - Upgrade Synapse to 0.33.7
-  - Automatically purge historic state and restart service once a day, removing the need for an external cron service
-  - Updated minimum docker and docker-compose version requirements
-- 2018-08-09 - `2018.8.1` - **Initial public release**
-- 2018-08-02 - `2018.8.0` - **Initial version**
-
+See `CHANGELOG.md`.
 
 ## Licenses
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ x-versions:
   services: &IMAGE_RAIDEN_SERVICES_VERSION
     image: raidennetwork/raiden-services:stable
   db: &IMAGE_DB_VERSION
-    image: raidennetwork/raiden-services-bundle:nightly-db
+    image: raidennetwork/raiden-services-bundle:2019.11.0-db
   synapse: &IMAGE_SYNAPSE_VERSION
-    image: raidennetwork/raiden-services-bundle:nightly-synapse
+    image: raidennetwork/raiden-services-bundle:2019.11.0-synapse
   well-known-server: &IMAGE_WELL_KNOWN_VERSION
-    image: raidennetwork/raiden-services-bundle:nightly-well_known_server
+    image: raidennetwork/raiden-services-bundle:2019.11.0-well_known_server
   traefik: &IMAGE_TRAEFIK_VERSION
     image: traefik:1.7
   purger: &IMAGE_PURGER_VERSION


### PR DESCRIPTION
~After merging, this requires manual tagging through github. I'm unsure, if this is going to trigger a tagged CI build though~

This must be merged through `merge commit` in order to preserve tagging!