### PR TITLE
Execute circleci builds on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,3 +57,17 @@ workflows:
       - build_synapse
       - build_db
       - build_well_known
+  tagged_images:
+    jobs:
+      - build_synapse:
+          filters:
+            tags:
+              only: /.*/
+      - build_db:
+          filters:
+            tags:
+              only: /.*/
+      - build_well_known:
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
The previous release failed, due to a missing configuration to execute circleCI builds on git tags.
This adds the `workflow` configuration, according to https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag to fix that.