### PR TITLE
Fixed docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,14 +164,6 @@ services:
         condition: service_healthy
       well_known_server:
         condition: service_healthy
-      synchrotron:
-        condition: service_started
-      client_reader:
-        condition: service_started
-      user_dir:
-        condition: service_started
-      event_creator:
-        condition: service_started
       pfs:
         condition: service_started
       ms:


### PR DESCRIPTION
The services synchrotron, client_reader, user_dir, event_creator were
removed because the configuration was changed from split to non-split.