### PR TITLE
Pin python 3.7 for now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-versions:
   traefik: &IMAGE_TRAEFIK_VERSION
     image: traefik:1.7
   purger: &IMAGE_PURGER_VERSION
-    image: python:3
+    image: python:3.7
 # /versions
 
 x-defaults: &services-defaults


### PR DESCRIPTION
As we found out the `purge` container only works on 3.7