### PR TITLE
Remove mycrypto server

### DIFF
--- a/known_servers.main.yaml
+++ b/known_servers.main.yaml
@@ -2,4 +2,3 @@
   - raidentransport.exchangeunion.com
   - persephone.raidentransport.digitalvirtues.com
   - raidentransport.ki-decentralized.com
-  - raidentransport.mycryptoapi.com


### PR DESCRIPTION
The MyCrypto provided server seems to be offline currently. 

Remove it until it is working again.