### PR TITLE
Reintroduce mycrypto server

### DIFF
--- a/known_servers.main.yaml
+++ b/known_servers.main.yaml
@@ -2,3 +2,4 @@
   - raidentransport.exchangeunion.com
   - persephone.raidentransport.digitalvirtues.com
   - raidentransport.ki-decentralized.com
+  - raidentransport.mycryptoapi.com


### PR DESCRIPTION
This reverts commit 071226d5ccec47a585e098383289318bdde99c26.

Reason: It is now online again and they setup alerting so that this is
caught by them earlier if it happens again.