### PR TITLE
Switch to current DB image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-versions:
   services: &IMAGE_RAIDEN_SERVICES_VERSION
     image: raidennetwork/raiden-services:stable
   db: &IMAGE_DB_VERSION
-    image: raidennetwork/raiden-services-bundle:2019.11.1-db
+    image: raidennetwork/raiden-services-bundle:nightly-db
   synapse: &IMAGE_SYNAPSE_VERSION
     image: raidennetwork/raiden-services-bundle:nightly-synapse
   well-known-server: &IMAGE_WELL_KNOWN_VERSION


### PR DESCRIPTION
With #88 merged we need to use the latest db image until we have a new release.