### PR TITLE
Update .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,7 +29,7 @@ WORKER_COUNT=8
 #DATA_DIR=/data
 
 ## URL to use to fetch federation whitelist
-#URL_KNOWN_FEDERATION_SERVERS=https://raw.githubusercontent.com/raiden-network/raiden-transport/master/known_servers.yaml
+#URL_KNOWN_FEDERATION_SERVERS=https://raw.githubusercontent.com/raiden-network/raiden-service-bundle/master/known_servers.yaml
 
 
 ### Services settings


### PR DESCRIPTION
changed the name of the link `...raiden-transport...` to `...raiden-service-bundle...` 