### PR TITLE
changing registered service url

### DIFF
--- a/register-service-provider.sh
+++ b/register-service-provider.sh
@@ -11,7 +11,7 @@ docker run --rm -it \
   -e SR_REGISTER_LOG_LEVEL=${LOG_LEVEL} \
   -e SR_REGISTER_KEYSTORE_FILE=/keystore/${KEYSTORE_FILE} \
   -e SR_REGISTER_PASSWORD=${PASSWORD} \
-  -e SR_REGISTER_SERVICE_URL=pfs.${SERVER_NAME} \
+  -e SR_REGISTER_SERVICE_URL=https://pfs.${SERVER_NAME} \
   -e SR_REGISTER_ETH_RPC=${ETH_RPC} \
   --env-file .env \
   ${IMAGE} \


### PR DESCRIPTION
According to @karlb the raiden clients only accept a Service URL that uses `https://pfs.${SERVER_NAME}`

@fredo please double-check that it is correct now