### PR TITLE
Use strings in log config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,8 @@ x-log-config: &log-config
   logging:
     driver: json-file
     options:
-      max-size: 20m
-      max-file: 10
+      max-size: "20m"
+      max-file: "10"
 
 services:
   # raiden-services containers


### PR DESCRIPTION
Using numbers apparently doesn't work
See the note below: https://docs.docker.com/config/containers/logging/configure/#configure-the-default-logging-driver