### PR TITLE
add prefix transport. as subdomain

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       - ${DATA_DIR:-./data}/well-known:/data_well_known
       - ${DATA_DIR:-./data}/synapse:/data
     environment:
-      - SERVER_NAME
+      - SERVER_NAME=transport.${SERVER_NAME}
       - URL_KNOWN_FEDERATION_SERVERS
     command: ["/synapse-venv/bin/python", "-m", "synapse.app.homeserver", "--config-path", "/config/synapse.yaml", "--config-path", "/config/workers/homeserver.yaml"]
     depends_on:
@@ -122,13 +122,13 @@ services:
     << : *log-config
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.synapse.rule=Host(`${SERVER_NAME}`)"
+      - "traefik.http.routers.synapse.rule=Host(`transport.${SERVER_NAME}`)"
       - "traefik.http.routers.synapse.tls=true"
       - "traefik.http.routers.synapse.tls.certresolver=le"
       - "traefik.http.routers.synapse.service=synapse"
       - "traefik.http.services.synapse.loadbalancer.server.port=8008"
       - "traefik.http.services.synapse.loadbalancer.healthcheck.path=/_matrix/client/versions"
-      - "traefik.http.routers.metrics.rule=Host(`metrics.${SERVER_NAME}`)"
+      - "traefik.http.routers.metrics.rule=Host(`metrics.transport.${SERVER_NAME}`)"
       - "traefik.http.routers.metrics.tls=true"
       - "traefik.http.routers.metrics.tls.certresolver=le"
       - "traefik.http.routers.metrics.middlewares=metrics-access-control@docker"
@@ -144,7 +144,7 @@ services:
       - ./config/synapse:/config
       - ${DATA_DIR:-./data}/synapse:/data
     environment:
-      - SERVER_NAME
+      - SERVER_NAME=transport.${SERVER_NAME}
     depends_on:
       synapse:
         condition: service_healthy
@@ -155,7 +155,7 @@ services:
     <<: *log-config
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.synchrotron.rule=Host(`${SERVER_NAME}`) && (PathPrefix(`/_matrix/client/{version:(v2_alpha|r0)}/sync`) || PathPrefix(`/_matrix/client/{version:(api/v1|v2_alpha|r0)}/events`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0)}/initialSync`) && PathPrefix(`/_matrix/client/{version:(api/v1|r0)}/rooms/{room:[^/]+}/initialSync`))"
+      - "traefik.http.routers.synchrotron.rule=Host(`transport.${SERVER_NAME}`) && (PathPrefix(`/_matrix/client/{version:(v2_alpha|r0)}/sync`) || PathPrefix(`/_matrix/client/{version:(api/v1|v2_alpha|r0)}/events`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0)}/initialSync`) && PathPrefix(`/_matrix/client/{version:(api/v1|r0)}/rooms/{room:[^/]+}/initialSync`))"
       - "traefik.http.routers.synchrotron.tls=true"
       - "traefik.http.routers.synchrotron.tls.certresolver=le"
       - "traefik.http.routers.synchrotron.service=synchrotron"
@@ -169,7 +169,7 @@ services:
       - ./config/synapse:/config
       - ${DATA_DIR:-./data}/synapse:/data
     environment:
-      - SERVER_NAME
+      - SERVER_NAME=transport.${SERVER_NAME}
     depends_on:
       synapse:
         condition: service_healthy
@@ -179,7 +179,7 @@ services:
     << : *log-config
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host(`${SERVER_NAME}`) && (PathPrefix(`/_matrix/federation/v1/{type:(backfill|event|event_auth|exchange_third_party_invite|get_missing_events|invite|make_join|make_leave|publicRoom|query|query_auth|send|send_join|send_leave|state|state_ids)}`) || PathPrefix(`/_matrix/federation/v2/{type:(invite|send_join|send_leave)}`) || PathPrefix(`/_matrix/key/v2/query`))"
+      - "traefik.frontend.rule=Host(`transport.${SERVER_NAME}`) && (PathPrefix(`/_matrix/federation/v1/{type:(backfill|event|event_auth|exchange_third_party_invite|get_missing_events|invite|make_join|make_leave|publicRoom|query|query_auth|send|send_join|send_leave|state|state_ids)}`) || PathPrefix(`/_matrix/federation/v2/{type:(invite|send_join|send_leave)}`) || PathPrefix(`/_matrix/key/v2/query`))"
       - "traefik.http.routers.federation_reader.tls=true"
       - "traefik.http.routers.federation_reader.tls.certresolver=le"
       - "traefik.http.routers.federation_reader.service=federation_reader"
@@ -192,7 +192,7 @@ services:
       - ./config/synapse:/config
       - ${DATA_DIR:-./data}/synapse:/data
     environment:
-      - SERVER_NAME
+      - SERVER_NAME=transport.${SERVER_NAME}
     depends_on:
       synapse:
         condition: service_healthy
@@ -208,7 +208,7 @@ services:
       - ./config/synapse:/config
       - ${DATA_DIR:-./data}/synapse:/data
     environment:
-      - SERVER_NAME
+      - SERVER_NAME=transport.${SERVER_NAME}
     depends_on:
       synapse:
         condition: service_healthy
@@ -217,7 +217,7 @@ services:
     << : *log-config
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host(`${SERVER_NAME}`) && (PathPrefix(`/_matrix/client/versions`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/publicRooms`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/joined_members`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/context/{context:.*}`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/members`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/state`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/account/3pid`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/keys/query`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/keys/changes`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/voip/turnServer`))"
+      - "traefik.frontend.rule=Host(`transport.${SERVER_NAME}`) && (PathPrefix(`/_matrix/client/versions`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/publicRooms`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/joined_members`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/context/{context:.*}`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/members`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/state`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/account/3pid`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/keys/query`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/keys/changes`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/voip/turnServer`))"
       - "traefik.http.routers.client_reader.tls=true"
       - "traefik.http.routers.client_reader.tls.certresolver=le"
       - "traefik.http.routers.client_reader.service=client_reader"
@@ -231,7 +231,7 @@ services:
       - ./config/synapse:/config
       - ${DATA_DIR:-./data}/synapse:/data
     environment:
-      - SERVER_NAME
+      - SERVER_NAME=transport.${SERVER_NAME}
     depends_on:
       synapse:
         condition: service_healthy
@@ -242,7 +242,7 @@ services:
     << : *log-config
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host(`${SERVER_NAME}`) && PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/user_directory/search`)"
+      - "traefik.frontend.rule=Host(`transport.${SERVER_NAME}`) && PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/user_directory/search`)"
       - "traefik.http.routers.user_dir.tls=true"
       - "traefik.http.routers.user_dir.tls.certresolver=le"
       - "traefik.http.routers.user_dir.service=user_dir"
@@ -256,7 +256,7 @@ services:
       - ./config/synapse:/config
       - ${DATA_DIR:-./data}/synapse:/data
     environment:
-      - SERVER_NAME
+      - SERVER_NAME=transport.${SERVER_NAME}
     depends_on:
       synapse:
         condition: service_healthy
@@ -267,7 +267,7 @@ services:
     << : *log-config
     labels:
       - "traefik.enable=true"
-      - "traefik.frontend.rule=Host(`${SERVER_NAME}`) && (PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/send`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/{action:(join|invite|leave|ban|unban|kick)}`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/join/`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/profile/`))"
+      - "traefik.frontend.rule=Host(`transport.${SERVER_NAME}`) && (PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/send`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/rooms/{room:.*}/{action:(join|invite|leave|ban|unban|kick)}`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/join/`) || PathPrefix(`/_matrix/client/{version:(api/v1|r0|unstable)}/profile/`))"
       - "traefik.http.routers.event_creator.tls=true"
       - "traefik.http.routers.event_creator.tls.certresolver=le"
       - "traefik.http.routers.event_creator.service=event_creator"
@@ -298,7 +298,7 @@ services:
     << : *log-config
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.well-known.rule=Host(`${SERVER_NAME}`) && PathPrefix(`/.well-known/matrix`)"
+      - "traefik.http.routers.well-known.rule=Host(`transport.${SERVER_NAME}`) && PathPrefix(`/.well-known/matrix`)"
       - "traefik.http.routers.well-known.entrypoints=websecure"
       - "traefik.http.routers.well-known.tls=true"
       - "traefik.http.routers.well-known.tls.certresolver=le"
@@ -312,11 +312,11 @@ services:
       synapse:
         condition: service_healthy
     environment:
-      - SERVER_NAME
+      - SERVER_NAME=transport.${SERVER_NAME}
       - URL_KNOWN_FEDERATION_SERVERS
     command:
       - "--own-server"
-      - "${SERVER_NAME}"
+      - "transport.${SERVER_NAME}"
       - "--log-level"
       - "DEBUG"
       - "--credentials-file"


### PR DESCRIPTION
This PR adds a prefix to the SERVER_NAME so we can align with the sub domains for pfs and ms.

it will be now:

Matrix: transport.${SERVER_NAME}
PFS: pfs.${SERVER_NAME}