### PR TITLE
Remove MSRC dependency on MS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,8 +98,6 @@ services:
     depends_on:
       synapse:
         condition: service_healthy
-      ms:
-        condition: service_healthy
     healthcheck:
       disable: true
     << : *log-config


### PR DESCRIPTION
While setting up a new RSB installation some components take longer than others to become operational (due to dependencies on external changes like the federation whitelist for example).

Previously there was a docker healthcheck dependency from MSRC -> MS.
This is problematic since the MS is one of the components that cannot start until the transport server has finalized setting up the bradcast rooms.

Therefore the MSRC wouldn't be started at all making later operator intervention necessary.

Removing this dependency has no negative effect on the setup since the MSRC will automatically restart if it cannot access the MS database.