### PR TITLE
Fix outdated known federation url in Synapse config renderer

### DIFF
--- a/build/synapse/Dockerfile
+++ b/build/synapse/Dockerfile
@@ -1,3 +1,11 @@
+ARG RAIDEN_VERSION
+FROM raidennetwork/raiden:${RAIDEN_VERSION} AS RAIDEN
+
+RUN /opt/venv/bin/python -c \
+    'from raiden.settings import DEFAULT_MATRIX_KNOWN_SERVERS; \
+    from raiden.constants import Environment; \
+    print(DEFAULT_MATRIX_KNOWN_SERVERS[Environment.PRODUCTION])' > /known_servers.default.txt
+
 FROM python:3.7
 LABEL maintainer="Raiden Network Team <contact@raiden.network>"
 
@@ -13,6 +21,7 @@ COPY eth_auth_provider.py /synapse-venv/lib/python3.7/site-packages/
 COPY admin_user_auth_provider.py /synapse-venv/lib/python3.7/site-packages/
 COPY synapse-entrypoint.sh /bin/
 COPY render_config_template.py /bin/
+COPY --from=RAIDEN /known_servers.default.txt /
 
 ENTRYPOINT ["/bin/synapse-entrypoint.sh"]
 CMD ["/synapse-venv/bin/python", "-m", "synapse.app.homeserver", "--config-path", "/config/synapse.yaml"]


### PR DESCRIPTION
The Synapse config renderer script contained a hardcoded and outdated reference to the known federation whitelist.

This is now replaced by reading the value from the current Raiden version during container build.