### PR TITLE
remove unused known servers files

### DIFF
--- a/known_servers.main.test.yaml
+++ b/known_servers.main.test.yaml
@@ -1,3 +1,0 @@
-## This file will be read by the Raiden client to discover the known Matrix servers when connecting to main networks
-  - transport.rsb01.test.raiden.network
-  - transport.rsb02.test.raiden.network

--- a/known_servers.test-split.yaml
+++ b/known_servers.test-split.yaml
@@ -1,6 +1,0 @@
-## This file will be read by the Raiden client to discover the known Matrix servers when connecting to test networks
-  - goerli.raiden.anyblock.tools
-  - transport.t01.testtransport.raiden.network
-  - transport.t02.testtransport.raiden.network
-  - raidentransport.ki-decentralized.com
-  - transport.raiden.dappnode.io


### PR DESCRIPTION
The federations for the test setup on goerli and mainnet before the release are down and thus the files can be removed. 