### PR TITLE
Fix purger known federation servers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,8 +338,9 @@ services:
         condition: service_healthy
     environment:
       - PURGE_SLEEP_UNTIL=05:00:00
+      - URL_KNOWN_FEDERATION_SERVERS
     command:
-      - "http://synapse:8008"
+      - "https://transport.${SERVER_NAME}"
       - "--docker-restart-label"
       - "purge_restart_container"
       - "--credentials-file"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [tool.black]
 line-length = 99
 target-version = ['py37']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,24 @@
+[flake8]
+ignore = B011, C814, E203, E402, E731, W503, W504, W391
+max-line-length = 99
+exclude = build,dist,.git,.venv
+
+[pep8]
+ignore = E731, E203, E402, W503, W504, C814
+max-line-length = 99
+
+[isort]
+line_length=99
+known_future_library=future
+known_first_party=raiden,raiden_contracts,scenario_player
+default_section=THIRDPARTY
+combine_as_imports=1
+# black compatibility
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+
 [mypy]
 ignore_missing_imports = True
 check_untyped_defs = True


### PR DESCRIPTION
The purger script used a hardcoded and outdated list of known federation servers if the container to be checked didn't have the `URL_KNOWN_FEDERATION_SERVERS` env variable set.

This is now fixed to always use the list from the corresponding Raiden version.

Also copies over the pylint, flake8 and isort configs from the main Raiden repo.