### PR TITLE
Revert removal of the test known servers file since it's still used by Raiden

### DIFF
--- a/known_servers.test.yaml
+++ b/known_servers.test.yaml
@@ -1,0 +1,5 @@
+## This file will be read by the Raiden client to discover the known Matrix servers when connecting to test networks
+  - transport.transport01.raiden.network
+  - transport.transport02.raiden.network
+  - transport.transport03.raiden.network
+  - transport.transport04.raiden.network


### PR DESCRIPTION
Raiden in development mode.