### PR TITLE
Do not break upon unavailable server

### DIFF
--- a/build/room_ensurer/room_ensurer.py
+++ b/build/room_ensurer/room_ensurer.py
@@ -89,11 +89,11 @@ class RoomInfo:
 
 class RoomEnsurer:
     def __init__(
-            self,
-            username: str,
-            password: str,
-            own_server_name: str,
-            known_servers_url: Optional[str] = None,
+        self,
+        username: str,
+        password: str,
+        own_server_name: str,
+        known_servers_url: Optional[str] = None,
     ):
         self._username = username
         self._password = password
@@ -214,7 +214,7 @@ class RoomEnsurer:
         self._ensure_admin_power_levels(room_infos[self._own_server_name])
 
     def _join_and_alias_room(
-            self, first_server_room_alias: str, own_server_room_alias: str
+        self, first_server_room_alias: str, own_server_room_alias: str
     ) -> None:
         response = self._own_api.join_room(first_server_room_alias)
         own_room_id = response.get("room_id")
@@ -291,12 +291,16 @@ class RoomEnsurer:
             return
 
         if own_user not in current_power_levels["users"]:
-            log.warning(f"{own_user} has not been granted administrative power levels yet. Doing nothing.")
+            log.warning(
+                f"{own_user} has not been granted administrative power levels yet. Doing nothing."
+            )
             return
 
         # the supposed power level dict could be just a subset of the current
         # because providers who left cannot be removed from other admins
-        if set(supposed_power_levels["users"].keys()).issubset(set(current_power_levels["users"].keys())):
+        if set(supposed_power_levels["users"].keys()).issubset(
+            set(current_power_levels["users"].keys())
+        ):
             log.debug(f"Power levels are up to date. Doing nothing.")
             return
 
@@ -323,7 +327,7 @@ class RoomEnsurer:
             gevent.spawn(self._connect, server_name, server_url)
             for server_name, server_url in self._known_servers.items()
         }
-        gevent.joinall(jobs, raise_error=True)
+        gevent.joinall(jobs)
         log.info("All servers connected")
         return {server_name: matrix_api for server_name, matrix_api in (job.get() for job in jobs)}
 

--- a/build/room_ensurer/room_ensurer.py
+++ b/build/room_ensurer/room_ensurer.py
@@ -149,9 +149,7 @@ class RoomEnsurer:
             log.warning("First server room missing")
             if self._is_first_server:
                 log.info("Creating room", server_name=self._own_server_name)
-                first_server_room_info = self._create_room(
-                    self._own_server_name, room_alias_prefix
-                )
+                first_server_room_info = self._create_room(room_alias_prefix)
                 room_infos[self._first_server_name] = first_server_room_info
             else:
                 raise EnsurerError("First server room missing.")
@@ -223,6 +221,9 @@ class RoomEnsurer:
 
     def _get_room(self, server_name: str, room_alias_prefix: str) -> Optional[RoomInfo]:
         api = self._apis[server_name]
+        if api is None:
+            return None
+
         room_alias_local = f"#{room_alias_prefix}:{server_name}"
         try:
             response = api.join_room(room_alias_local)
@@ -308,8 +309,8 @@ class RoomEnsurer:
         except MatrixError:
             log.debug("Could not set power levels", room_aliases=room_info.aliases)
 
-    def _create_room(self, server_name: str, room_alias_prefix: str) -> RoomInfo:
-        api = self._apis[server_name]
+    def _create_room(self, room_alias_prefix: str) -> RoomInfo:
+        api = self._apis[self._own_server_name]
         server_admin_power_levels = self._create_server_user_power_levels()
         response = api.create_room(
             room_alias_prefix,
@@ -317,8 +318,8 @@ class RoomEnsurer:
             power_level_content_override=server_admin_power_levels,
         )
 
-        room_alias = f"#{room_alias_prefix}:{server_name}"
-        return RoomInfo(response["room_id"], {room_alias}, server_name)
+        room_alias = f"#{room_alias_prefix}:{self._own_server_name}"
+        return RoomInfo(response["room_id"], {room_alias}, self._own_server_name)
 
     def _connect_all(self) -> Dict[str, GMatrixHttpApi]:
         jobs = {


### PR DESCRIPTION
There was a bug when any of the known servers is not available it would throw an error which is unhandled. The Room Ensurer breaks and does not join the broadcast rooms even if it could.

# Solution
The error now gets catched and throws a log message. But the RE continues to ensure the rooms. 