### PR TITLE
Admin api improvements [DO NOT MERGE BEFORE SYNAPSE UPGRADE]

### DIFF
--- a/build/purger/purger.py
+++ b/build/purger/purger.py
@@ -267,13 +267,11 @@ def _fetch_new_members_for_network(
     api: GMatrixHttpApi, user_activity: Dict[str, int], discovery_room: RoomInfo, current_time: int
 ) -> None:
     try:
-        response = api.get_room_members(discovery_room.room_id)
+        response = api._send("GET", f"/_synapse/admin/v1/rooms/{discovery_room.room_id}/members")
         room_members = [
-            event["state_key"]
-            for event in response["chunk"]
-            if event["content"]["membership"] == "join"
-            and event["state_key"].split(":")[1] == urlparse(api.base_url).netloc
-            and not event["state_key"].find("admin")
+            member
+            for member in response["members"]
+            if member.split(":")[1] == urlparse(api.base_url).netloc and not member.find("admin")
         ]
 
         # Add new members with an overdue activity time

--- a/build/purger/purger.py
+++ b/build/purger/purger.py
@@ -14,13 +14,7 @@ import yaml
 from matrix_client.errors import MatrixError
 from typing_extensions import TypedDict
 
-from raiden.constants import (
-    DISCOVERY_DEFAULT_ROOM,
-    MONITORING_BROADCASTING_ROOM,
-    PATH_FINDING_BROADCASTING_ROOM,
-    Environment,
-    Networks,
-)
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, Environment, Networks
 from raiden.network.transport.matrix import make_room_alias
 from raiden.network.transport.matrix.client import GMatrixHttpApi
 from raiden.settings import DEFAULT_MATRIX_KNOWN_SERVERS
@@ -108,12 +102,7 @@ def purge(
                 continue
             global_user_activity["network_to_users"][str(network.value)] = dict()
 
-        # get broadcast room ids for all networks
-        network_to_broadcast_rooms = get_network_to_broadcast_rooms(api)
-
-        new_global_user_activity = run_user_purger(
-            api, global_user_activity, network_to_broadcast_rooms
-        )
+        new_global_user_activity = run_user_purger(api, global_user_activity)
 
         # write the updated user activity to file
         USER_ACTIVITY_PATH.write_text(json.dumps(cast(Dict[str, Any], new_global_user_activity)))
@@ -159,72 +148,40 @@ def purge(
 
 
 def run_user_purger(
-    api: GMatrixHttpApi,
-    global_user_activity: UserActivityInfo,
-    network_to_broadcast_rooms: Dict[str, List[RoomInfo]],
+    api: GMatrixHttpApi, global_user_activity: UserActivityInfo,
 ) -> UserActivityInfo:
     """
     The user purger mechanism finds inactive users which have been offline
-    longer than the threshold time and will kick them out of the global rooms
-    to clean up the server's database and reduce load.
+    longer than the threshold time and will delete them. By deactivating them
+    with {"erase": True} they get removed from all rooms. Empty rooms will be deleted
+    in the database.
     Each server is responsible for its own users
 
     :param api: Api object to own server
     :param global_user_activity: content of user activity file
-    :param network_to_broadcast_rooms: RoomInfo Objects of all broadcast rooms
-    :return: None
+    :return: updated list of user activities
     """
 
     # perform update on user presence for due users
     # receive a list for due users on each network
-    due_users = update_user_activity(api, global_user_activity, network_to_broadcast_rooms)
+    due_users = update_user_activity(api, global_user_activity)
     # purge due users form rooms
-    purge_inactive_users(api, global_user_activity, network_to_broadcast_rooms, due_users)
+    purge_inactive_users(api, global_user_activity, due_users)
 
     return global_user_activity
 
 
-def get_network_to_broadcast_rooms(api: GMatrixHttpApi) -> Dict[str, List[RoomInfo]]:
-
-    room_alias_fragments = [
-        DISCOVERY_DEFAULT_ROOM,
-        PATH_FINDING_BROADCASTING_ROOM,
-        MONITORING_BROADCASTING_ROOM,
-    ]
-
-    server = urlparse(api.base_url).netloc
-    network_to_broadcast: Dict[str, List[RoomInfo]] = dict()
-
-    for network in Networks:
-        broadcast_room_infos: List[RoomInfo] = list()
-        network_to_broadcast[str(network.value)] = broadcast_room_infos
-        for room_alias_fragment in room_alias_fragments:
-            broadcast_room_alias = make_room_alias(ChainID(network.value), room_alias_fragment)
-            local_room_alias = f"#{broadcast_room_alias}:{server}"
-
-            try:
-                room_id = api.get_room_id(local_room_alias)
-                broadcast_room_infos.append(RoomInfo(room_id, broadcast_room_alias, server))
-            except MatrixError as ex:
-                click.secho(f"Could not find room {broadcast_room_alias} with error {ex}")
-
-    return network_to_broadcast
-
-
 def update_user_activity(
-    api: GMatrixHttpApi,
-    global_user_activity: UserActivityInfo,
-    broadcast_rooms: Dict[str, List[RoomInfo]],
+    api: GMatrixHttpApi, global_user_activity: UserActivityInfo,
 ) -> Dict[str, List[str]]:
     """
-    runs update on users' presences which are about to be kicked.
+    runs update on users' presences which are about to be deleted.
     If they are still overdue they are going to be added to the list
-    of users to be kicked. Presence updates are included in the
+    of users to be deleted. Presence updates are included in the
     global list which is going to be stored in the user_activity_file
     :param api: api to its own server
     :param global_user_activity: content of user_activity_file
-    :param broadcast_rooms: room information for broadcast rooms
-    :return: a list of due users to be kicked
+    :return: a list of due users to be deleted
     """
     current_time = int(time.time())
     last_user_activity_update = global_user_activity["last_update"]
@@ -235,7 +192,7 @@ def update_user_activity(
     # check if new members have to be fetched
     # new members only have to be fetched every
     # USER_PURGING_THRESHOLD since that is the earliest time
-    # new members are able to be kicked. This keeps the load on
+    # new members are able to be deleted. This keeps the load on
     # the server as low as possible
     if last_user_activity_update < current_time - USER_PURGING_THRESHOLD:
         fetch_new_members = True
@@ -243,16 +200,16 @@ def update_user_activity(
 
     for network_key, user_activity in network_to_users.items():
         if fetch_new_members:
-            network_boradcast_rooms = broadcast_rooms[network_key]
-            if len(network_boradcast_rooms) == 0:
+            discovery_room = get_discovery_room(api, int(network_key))
+            if discovery_room is None:
                 click.secho(
-                    f"No broadcast rooms found for network {network_key}, skipping.", fg="yellow"
+                    f"No discovery room found for network {network_key}, skipping.", fg="yellow"
                 )
                 continue
             _fetch_new_members_for_network(
                 api=api,
-                user_activity=network_to_users[network_key],
-                discovery_room=network_boradcast_rooms[0],
+                user_activity=user_activity,
+                discovery_room=discovery_room,
                 current_time=current_time,
             )
 
@@ -263,15 +220,31 @@ def update_user_activity(
     return network_to_due_users
 
 
+def get_discovery_room(api: GMatrixHttpApi, network_value: int) -> Optional[RoomInfo]:
+
+    server = urlparse(api.base_url).netloc
+    discovery_room_alias = make_room_alias(ChainID(network_value), DISCOVERY_DEFAULT_ROOM)
+    local_room_alias = f"#{discovery_room_alias}:{server}"
+
+    try:
+        room_id = api.get_room_id(local_room_alias)
+        return RoomInfo(room_id, discovery_room_alias, server)
+    except MatrixError as ex:
+        click.secho(f"Could not find room {discovery_room_alias} with error {ex}")
+
+    return None
+
+
 def _fetch_new_members_for_network(
     api: GMatrixHttpApi, user_activity: Dict[str, int], discovery_room: RoomInfo, current_time: int
 ) -> None:
     try:
         response = api._send("GET", f"/_synapse/admin/v1/rooms/{discovery_room.room_id}/members")
+        server_name = urlparse(api.base_url).netloc
         room_members = [
             member
             for member in response["members"]
-            if member.split(":")[1] == urlparse(api.base_url).netloc and not member.find("admin")
+            if member.split(":")[1] == server_name and not member.startswith("@admin")
         ]
 
         # Add new members with an overdue activity time
@@ -285,7 +258,7 @@ def _fetch_new_members_for_network(
 
 
 def _update_user_activity_for_network(
-    api: GMatrixHttpApi, user_activity: Dict[str, Any], current_time: int
+    api: GMatrixHttpApi, user_activity: Dict[str, int], current_time: int
 ) -> List[str]:
     deadline = current_time - USER_PURGING_THRESHOLD
 
@@ -323,7 +296,6 @@ def _update_user_activity_for_network(
 def purge_inactive_users(
     api: GMatrixHttpApi,
     global_user_activity: UserActivityInfo,
-    network_to_broadcast_rooms: Dict[str, List[RoomInfo]],
     network_to_due_users: Dict[str, List[str]],
 ) -> None:
     for network_key, due_users in network_to_due_users.items():
@@ -331,30 +303,28 @@ def purge_inactive_users(
             api=api,
             user_activity=global_user_activity["network_to_users"][network_key],
             due_users=due_users,
-            broadcast_rooms=network_to_broadcast_rooms[network_key],
         )
 
 
 def _purge_inactive_users_for_network(
-    api: GMatrixHttpApi,
-    user_activity: Dict[str, int],
-    due_users: List[str],
-    broadcast_rooms: List[RoomInfo],
+    api: GMatrixHttpApi, user_activity: Dict[str, int], due_users: List[str],
 ) -> None:
     for user_id in due_users:
-        for room in broadcast_rooms:
-            try:
-                # kick the user and remove him from the user_activity_file
-                last_ago = (int(time.time()) - user_activity[user_id]) / (60 * 60 * 24)
-                api.kick_user(room.room_id, user_id)
-                user_activity.pop(user_id, None)
-                click.secho(
-                    f"{user_id} kicked from room {room.alias}. Offline for {last_ago} days."
-                )
-            except MatrixError as ex:
-                click.secho(f"Could not kick user from room {room.alias} with error {ex}")
-            finally:
-                time.sleep(0.1)
+        try:
+            # delete user account and remove him from the user_activity_file
+            last_ago = (int(time.time()) - user_activity[user_id]) / (60 * 60 * 24)
+            api._send(
+                "POST",
+                f"/deactivate/{user_id}",
+                content={"erase": True},
+                api_path="/_synapse/admin/v1",
+            )
+            user_activity.pop(user_id, None)
+            click.secho(f"{user_id} deleted. Offline for {last_ago} days.")
+        except MatrixError as ex:
+            click.secho(f"Could not delete user {user_id} with error {ex}")
+        finally:
+            time.sleep(0.1)
 
 
 if __name__ == "__main__":

--- a/tests/test_purger.py
+++ b/tests/test_purger.py
@@ -5,15 +5,11 @@ from random import randint
 from typing import Any, Dict
 
 import pytest
-
-from build.purger.purger import (
-    USER_PURGING_THRESHOLD,
-    get_network_to_broadcast_rooms,
-    run_user_purger,
-)
-from raiden.constants import Networks
+from build.purger.purger import USER_PURGING_THRESHOLD, run_user_purger
 from tests.file_templates import USER_PRESENCE_TEMPLATE
 from tests.utils import GMatrixHttpApiTest, create_user_activity_dict
+
+from raiden.constants import Networks
 
 
 @pytest.fixture
@@ -80,11 +76,8 @@ def mocked_matrix_api(
 def test_due_users_get_kicked(
     mocked_matrix_api, global_user_activity, active_users_count, activity_changed_count, networks
 ):
-    network_to_broadcast_rooms = get_network_to_broadcast_rooms(mocked_matrix_api)
 
-    new_global_user_activity = run_user_purger(
-        mocked_matrix_api, global_user_activity, network_to_broadcast_rooms
-    )
+    new_global_user_activity = run_user_purger(mocked_matrix_api, global_user_activity)
     # assert that number of user reduced as expected
     assert (
         len(new_global_user_activity["network_to_users"][str(networks[0].value)])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,14 +29,14 @@ class GMatrixHttpApiTest(GMatrixHttpApi):
 
         raise MatrixRequestError()
 
-    def kick_user(self, room_id, user_id):
-        return None
-
     def get_joined_members(self, room_id):
         return self.user_presence
 
-    def get_room_members(self, room_id):
-        return {"chunk": []}
+    # this is a hack because _send is only called upon fetching room members via admin api
+    def _send(
+        self, method, path, content=None, query_params=None, headers=None, api_path="",
+    ):
+        return {"members": []}
 
 
 def create_user_activity_dict(size: int, lower_bound: int, upper_bound: int) -> Dict[str, int]:


### PR DESCRIPTION
New Admin API endpoints improve user purging

# Optimizations
The user purger was refactored to use new endpoints and additionally clean up the database besides reducing operational load.

## Fetch room members endpoint
A new admin api endpoint allows a server admin to fetch the current members of a room. This is much more convinient and efficients then querying all state events of the room.

## Deactivating user accounts
Inactive users now gets deactivated and erased from the database. This has a couple of advantages. Besides freeing up space for the user data, footprints of the users also gets erased. They get removed from all rooms they have joined, including private rooms. Furthermore, empty rooms automatically get removed as well.

These optimizations should help the database to be cleaned up where it is possible.