### PR TITLE
Expose PFS, MS metrics & Fix HTTPS redirect

### DIFF
--- a/config/traefik/traefik.toml
+++ b/config/traefik/traefik.toml
@@ -6,30 +6,14 @@
 [entryPoints]
   [entryPoints.web]
     address = ":80"
+    [entryPoints.web.http.redirections]
+      [entryPoints.web.http.redirections.entryPoint]
+        to = "websecure"
   [entryPoints.websecure]
     address = ":443"
 
-[http.routers]
-  [http.routers.http_catchall]
-    entryPoints = ["web"]
-    middlewares = ["https_redirect"]
-    rule = "HostRegexp(`{any:.+}`)"
-    service = "noop"
-
-[http.services]
-  # noop service, the URL will be never called
-  [http.services.noop.loadBalancer]
-    [[http.services.noop.loadBalancer.servers]]
-      url = "http://0.0.0.0:0"
-
-[http.middlewares]
-  [http.middlewares.https_redirect.redirectScheme]
-    scheme = "https"
-    permanent = true
-
 [api]
   dashboard = true
-
 
 [providers.docker]
   watch = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
     << : *services-defaults
     command: ["python3", "-m", "pathfinding_service.cli", "--matrix-server", "https://transport.${SERVER_NAME}"]
     restart: always
-    ports:
-      - 6001:6000
     environment:
       - PFS_STATE_DB=/state/pfs-state.db
       - PFS_HOST=0.0.0.0
@@ -65,17 +63,25 @@ services:
       - "traefik.http.routers.pfs.entrypoints=websecure"
       - "traefik.http.routers.pfs.tls=true"
       - "traefik.http.routers.pfs.tls.certresolver=le"
+      - "traefik.http.routers.pfs.middlewares=pfs-restrict-metrics@docker"
+      - "traefik.http.middlewares.pfs-restrict-metrics.stripprefix.prefixes=/api/v1/metrics"
       - "traefik.http.routers.pfs.service=pfs"
       - "traefik.http.services.pfs.loadbalancer.healthcheck.path=/api/v1/info"
+      - "traefik.http.routers.metrics-pfs.rule=Host(`metrics.pfs.${SERVER_NAME}`)"
+      - "traefik.http.routers.metrics-pfs.tls=true"
+      - "traefik.http.routers.metrics-pfs.tls.certresolver=le"
+      - "traefik.http.routers.metrics-pfs.middlewares=metrics-pfs-access-control@docker,metrics-pfs-metrics-path@docker"
+      - "traefik.http.middlewares.metrics-pfs-access-control.ipwhitelist.sourcerange=${CIDR_ALLOW_METRICS}"
+      - "traefik.http.middlewares.metrics-pfs-metrics-path.addprefix.prefix=/api/v1"
 
   ms:
     << : *services-defaults
     command: ["python3", "-m", "monitoring_service.cli"]
     restart: always
-    ports:
-      - 6002:6000
     environment:
       - MS_STATE_DB=/state/ms-state.db
+      - MS_HOST=0.0.0.0
+      - MS_PORT=6000
       - MS_LOG_LEVEL=${LOG_LEVEL}
       - MS_KEYSTORE_FILE=/keystore/${KEYSTORE_FILE}
       - MS_PASSWORD=${PASSWORD}
@@ -85,13 +91,27 @@ services:
       test: 'python3 -c "import sqlite3, sys; from time import sleep; conn=sqlite3.connect(\"/state/ms-state.db\"); r = lambda: conn.execute(\"select latest_committed_block from blockchain ORDER BY latest_committed_block DESC LIMIT 1;\").fetchone()[0]; one = r(); sleep(25); two = r(); print(two); sys.exit(0 if two > one else 1)"'
       start_period: 30s
     << : *log-config
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ms.rule=Host(`ms.${SERVER_NAME}`)"
+      - "traefik.http.routers.ms.entrypoints=websecure"
+      - "traefik.http.routers.ms.tls=true"
+      - "traefik.http.routers.ms.tls.certresolver=le"
+      - "traefik.http.routers.ms.middlewares=ms-restrict-metrics@docker"
+      - "traefik.http.routers.ms.service=ms"
+      - "traefik.http.middlewares.ms-restrict-metrics.stripprefix.prefixes=/api/v1/metrics"
+      - "traefik.http.services.ms.loadbalancer.healthcheck.path=/api/v1/info"
+      - "traefik.http.routers.metrics-ms.rule=Host(`metrics.ms.${SERVER_NAME}`)"
+      - "traefik.http.routers.metrics-ms.tls=true"
+      - "traefik.http.routers.metrics-ms.tls.certresolver=le"
+      - "traefik.http.routers.metrics-ms.middlewares=metrics-ms-access-control@docker,metrics-ms-metrics-path@docker"
+      - "traefik.http.middlewares.metrics-ms-access-control.ipwhitelist.sourcerange=${CIDR_ALLOW_METRICS}"
+      - "traefik.http.middlewares.metrics-ms-metrics-path.addprefix.prefix=/api/v1"
 
   msrc:
     << : *services-defaults
     command: ["python3", "-m", "request_collector.cli", "--matrix-server", "https://transport.${SERVER_NAME}"]
     restart: always
-    ports:
-      - 6003:6000
     environment:
       - MSRC_STATE_DB=/state/ms-state.db
       - MSRC_LOG_LEVEL=${LOG_LEVEL}


### PR DESCRIPTION
- Expose PFS & MS metrics
  - They are available from the whitelisted IPs on:
    - `metrics.pfs.<server-name>/metrics`
    - `metrics.ms.<server-name>/metrics`
- Fix http -> https redirect
  Fixes: #160

