### PR TITLE
Release 2020.10.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,17 +1,17 @@
 [bumpversion]
-current_version = 2020.10.0
+current_version = 2020.10.1
 commit = True
 tag = True
 tag_name = {new_version}
 parse = (?P<year>\d+)\.(?P<month>\d+)\.(?P<release>\d+)(?:rc(?P<rc>\d+))?
-serialize =
+serialize = 
 	{year}.{month}.{release}rc{rc}
 	{year}.{month}.{release}
 
 [bumpversion:file:README.md]
 
 [bumpversion:part:month]
-values =
+values = 
 	01
 	02
 	03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+- 2020-10-06 - `2020.10.1` - **Bugfix release**
+  - Upgrade to Raiden Services `v0.13.1`
+    - This fixes a bug with the services metrics 
 - 2020-10-05 - `2020.10.0` - **Upgrade release**
   - Upgrade Synapse to `v1.19.1`
   - Upgrade Raiden Services to `v0.13.0`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository contains the documentation and configuration necessary to run a
 Raiden Service Bundle.
 
-**Current release:** [2020.10.0](https://github.com/raiden-network/raiden-service-bundle/tree/2020.10.0)
+**Current release:** [2020.10.1](https://github.com/raiden-network/raiden-service-bundle/tree/2020.10.1)
 
 ## Table of Contents
 
@@ -145,11 +145,11 @@ host an application that relies on either Cookies or LocalStorage for security r
 
 ### Installing the RSB
 
-1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2020.10.0)
+1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2020.10.1)
    to a suitable location on the server:
 
    ```shell
-   git clone -b 2020.10.0 https://github.com/raiden-network/raiden-service-bundle.git
+   git clone -b 2020.10.1 https://github.com/raiden-network/raiden-service-bundle.git
    ```
 1. Copy `.env.template` to `.env` and modify the values to fit your setup. Please read [Configuring the `.env` file](#configuring-the-env-file) for detailed information.
    - We would appreciate it if you allow us access to the monitoring interfaces

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrading existing installations
 
-## From `2020.06.0` to `2020.10.0`
+## From `2020.06.0`
 
 Due to the significant jump in Synapse version we recommend to wipe the Synapse 
 database when upgrading.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.3'
 # versions: change these in order to pin versions for a certain releases
 x-versions:
   services: &IMAGE_RAIDEN_SERVICES_VERSION
-    image: raidennetwork/raiden-services:v0.13.0
+    image: raidennetwork/raiden-services:v0.13.1
   db: &IMAGE_DB_VERSION
     image: raidennetwork/raiden-service-bundle:2020.10.0-db
   synapse: &IMAGE_SYNAPSE_VERSION
@@ -66,15 +66,14 @@ services:
       - "traefik.http.routers.pfs.tls=true"
       - "traefik.http.routers.pfs.tls.certresolver=le"
       - "traefik.http.routers.pfs.middlewares=pfs-restrict-metrics@docker"
-      - "traefik.http.middlewares.pfs-restrict-metrics.stripprefix.prefixes=/api/v1/metrics"
+      - "traefik.http.middlewares.pfs-restrict-metrics.stripprefix.prefixes=/metrics"
       - "traefik.http.routers.pfs.service=pfs"
       - "traefik.http.services.pfs.loadbalancer.healthcheck.path=/api/v1/info"
       - "traefik.http.routers.metrics-pfs.rule=Host(`metrics.pfs.${SERVER_NAME}`)"
       - "traefik.http.routers.metrics-pfs.tls=true"
       - "traefik.http.routers.metrics-pfs.tls.certresolver=le"
-      - "traefik.http.routers.metrics-pfs.middlewares=metrics-pfs-access-control@docker,metrics-pfs-metrics-path@docker"
+      - "traefik.http.routers.metrics-pfs.middlewares=metrics-pfs-access-control@docker"
       - "traefik.http.middlewares.metrics-pfs-access-control.ipwhitelist.sourcerange=${CIDR_ALLOW_METRICS}"
-      - "traefik.http.middlewares.metrics-pfs-metrics-path.addprefix.prefix=/api/v1"
 
   ms:
     << : *services-defaults
@@ -101,14 +100,13 @@ services:
       - "traefik.http.routers.ms.tls.certresolver=le"
       - "traefik.http.routers.ms.middlewares=ms-restrict-metrics@docker"
       - "traefik.http.routers.ms.service=ms"
-      - "traefik.http.middlewares.ms-restrict-metrics.stripprefix.prefixes=/api/v1/metrics"
+      - "traefik.http.middlewares.ms-restrict-metrics.stripprefix.prefixes=/metrics"
       - "traefik.http.services.ms.loadbalancer.healthcheck.path=/api/v1/info"
       - "traefik.http.routers.metrics-ms.rule=Host(`metrics.ms.${SERVER_NAME}`)"
       - "traefik.http.routers.metrics-ms.tls=true"
       - "traefik.http.routers.metrics-ms.tls.certresolver=le"
-      - "traefik.http.routers.metrics-ms.middlewares=metrics-ms-access-control@docker,metrics-ms-metrics-path@docker"
+      - "traefik.http.routers.metrics-ms.middlewares=metrics-ms-access-control@docker"
       - "traefik.http.middlewares.metrics-ms-access-control.ipwhitelist.sourcerange=${CIDR_ALLOW_METRICS}"
-      - "traefik.http.middlewares.metrics-ms-metrics-path.addprefix.prefix=/api/v1"
 
   msrc:
     << : *services-defaults


### PR DESCRIPTION
Upgrade to Raiden Services `v0.13.1` to fix a mishap with the metrics path.