### PR TITLE
Release 2020.10.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
-current_version = 2020.10.2
+current_version = 2020.10.3
 commit = True
 tag = True
 tag_name = {new_version}
 parse = (?P<year>\d+)\.(?P<month>\d+)\.(?P<release>\d+)(?:rc(?P<rc>\d+))?
-serialize =
+serialize = 
 	{year}.{month}.{release}rc{rc}
 	{year}.{month}.{release}
 
@@ -13,7 +13,7 @@ serialize =
 [bumpversion:file:docker-compose.yml]
 
 [bumpversion:part:month]
-values =
+values = 
 	01
 	02
 	03

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,14 +4,16 @@ commit = True
 tag = True
 tag_name = {new_version}
 parse = (?P<year>\d+)\.(?P<month>\d+)\.(?P<release>\d+)(?:rc(?P<rc>\d+))?
-serialize = 
+serialize =
 	{year}.{month}.{release}rc{rc}
 	{year}.{month}.{release}
 
 [bumpversion:file:README.md]
 
+[bumpversion:file:docker-compose.yml]
+
 [bumpversion:part:month]
-values = 
+values =
 	01
 	02
 	03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Changelog
+- 2020-10-08 - `2020.10.3` - **Bugfix release**
+  - Fix an issue with the release process
 - 2020-10-07 - `2020.10.2` - **Bugfix release**
   - Fix a few small bugs
     - Stop Room Ensurer crashing when other servers are unreachable

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository contains the documentation and configuration necessary to run a
 Raiden Service Bundle.
 
-**Current release:** [2020.10.2](https://github.com/raiden-network/raiden-service-bundle/tree/2020.10.2)
+**Current release:** [2020.10.3](https://github.com/raiden-network/raiden-service-bundle/tree/2020.10.3)
 
 ## Table of Contents
 
@@ -145,11 +145,11 @@ host an application that relies on either Cookies or LocalStorage for security r
 
 ### Installing the RSB
 
-1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2020.10.2)
+1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2020.10.3)
    to a suitable location on the server:
 
    ```shell
-   git clone -b 2020.10.2 https://github.com/raiden-network/raiden-service-bundle.git
+   git clone -b 2020.10.3 https://github.com/raiden-network/raiden-service-bundle.git
    ```
 1. Copy `.env.template` to `.env` and modify the values to fit your setup. Please read [Configuring the `.env` file](#configuring-the-env-file) for detailed information.
    - We would appreciate it if you allow us access to the monitoring interfaces

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,15 @@ x-versions:
   services: &IMAGE_RAIDEN_SERVICES_VERSION
     image: raidennetwork/raiden-services:v0.13.1
   db: &IMAGE_DB_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.2-db
+    image: raidennetwork/raiden-service-bundle:2020.10.3-db
   synapse: &IMAGE_SYNAPSE_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.2-synapse
+    image: raidennetwork/raiden-service-bundle:2020.10.3-synapse
   well-known-server: &IMAGE_WELL_KNOWN_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.2-well_known_server
+    image: raidennetwork/raiden-service-bundle:2020.10.3-well_known_server
   room_ensurer: &IMAGE_ROOM_ENSURER_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.2-room_ensurer
+    image: raidennetwork/raiden-service-bundle:2020.10.3-room_ensurer
   purger: &IMAGE_PURGER_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.2-purger
+    image: raidennetwork/raiden-service-bundle:2020.10.3-purger
   redis: &IMAGE_REDIS_VERSION
     image: redis:6.0
   metrics_db: &IMAGE_METRICS_DB_VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,15 @@ x-versions:
   services: &IMAGE_RAIDEN_SERVICES_VERSION
     image: raidennetwork/raiden-services:v0.13.1
   db: &IMAGE_DB_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.0-db
+    image: raidennetwork/raiden-service-bundle:2020.10.2-db
   synapse: &IMAGE_SYNAPSE_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.0-synapse
+    image: raidennetwork/raiden-service-bundle:2020.10.2-synapse
   well-known-server: &IMAGE_WELL_KNOWN_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.0-well_known_server
+    image: raidennetwork/raiden-service-bundle:2020.10.2-well_known_server
   room_ensurer: &IMAGE_ROOM_ENSURER_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.0-room_ensurer
+    image: raidennetwork/raiden-service-bundle:2020.10.2-room_ensurer
   purger: &IMAGE_PURGER_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.10.0-purger
+    image: raidennetwork/raiden-service-bundle:2020.10.2-purger
   redis: &IMAGE_REDIS_VERSION
     image: redis:6.0
   metrics_db: &IMAGE_METRICS_DB_VERSION


### PR DESCRIPTION
Fix an issue in the release process.
The bumpversion config file didn't include the `docker-compose.yaml` which lead to old container builds being used.