### PR TITLE
[synapse] Disable retention policy

### DIFF
--- a/config/synapse/synapse.template.yaml
+++ b/config/synapse/synapse.template.yaml
@@ -136,7 +136,7 @@ alias_creation_rules:
 
 ## Message Retention Policy ##
 retention:
-  enabled: true
+  enabled: false
   default_policy:
     min_lifetime: 14d # not in use by the servers yet
     max_lifetime: 15d


### PR DESCRIPTION
In our test federation all servers have
showed steep increase in db size with each retention policy related
purging run.

Until we have clear signs of improvement for that behavior, we should
disable it per default.