### PR TITLE
[node_exporter] Change image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,9 @@ x-versions:
   metrics_redis: &IMAGE_METRICS_REDIS_VERSION
     image: oliver006/redis_exporter:v1.12.0
   traefik: &IMAGE_TRAEFIK_VERSION
-     image: traefik:2.2
+    image: traefik:2.2
   node_exporter: &IMAGE_NODE_EXPORTER
-    image: quay.io/prometheus/node-exporter:v2.22.1
+    image: quay.io/prometheus/node-exporter:v1.0.1
 # /versions
 
 x-defaults: &services-defaults


### PR DESCRIPTION
~~Unfortunately pulling a tag other than `latest` from quay.io results in~~
```
ERROR: manifest for quay.io/prometheus/node-exporter:v2.22.1 not found: manifest unknown: manifest unknown
```
~~so I'm tagging it `latest` for now.~~

Changed to the correct tag for the image `prometheus/node_exporter` which is `v1.0.1`. This works now reliably. Sorry, my bad!