### PR TITLE
Increase rate limits to fix initial room ensurer

### DIFF
--- a/config/synapse/synapse.template.yaml
+++ b/config/synapse/synapse.template.yaml
@@ -51,11 +51,23 @@ update_user_directory: False
 
 ## Ratelimiting
 
+rc_joins:
+  local:
+    per_second: 10
+    burst_count: 30
+  remote:
+    per_second: 10
+    burst_count: 30
+
+rc_admin_redaction:
+  per_second: 10
+  burst_count: 30
+
 rc_message:
   # Number of messages a client can send per second on average
-  per_second: 30
+  per_second: 300
   # Number of message a client can send before being throttled
-  burst_count: 200
+  burst_count: 2000
 
 rc_login:
   address:


### PR DESCRIPTION
Running the `room_ensurer` against a server that has too low `rc_joins` settings can lead to an inconsistent server
state, where rooms are created but can not be joined by the admin account in order to set up the correct power levels.

These values were found "empirically", by restarting the test federation from scratch until it finally worked.

One extra note: The working setup was acquired by bringing up the federation _without_ the `room_ensurer`, and then
manually adding the `room_ensurer` one by one:

```bash
for SERVER in $SERVER_LIST; 
do 
    ssh $SERVER "cd /etc/containers/rsb && docker-compose down && \
    rm -r /data/200gb/rsb-db" &; 
done

for SERVER in $SERVER_LIST; 
do 
    ssh $SERVER "mkdir /data/200gb/rsb-db && cd /etc/containers/rsb && \
    docker-compose up --scale room_ensurer=0 -d" &; 
done

for SERVER in $SERVER_LIST; 
do 
    ssh $SERVER "cd /etc/containers/rsb && docker-compose up -d";
done
```