### PR TITLE
Release 2020.11.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2020.11.1
+current_version = 2020.11.2
 commit = True
 tag = True
 tag_name = {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Changelog
+
+- 2020-11-25 - `2020.11.2` - **Bugfix Release**
+  - **Please check UPGRADING.md**
+  - Really upgrade to Synapse `v1.22.1`.
+  - Upgrade `raiden-services` to `v0.13.2`
 - 2020-11-24 - `2020.11.1` - **Maintenance Release**
   - **Please check UPGRADING.md**
-  - Upgrade to Synapse `v1.22.1`
+  - ~~Upgrade to Synapse `v1.22.1`~~
   - Add configuration for new federation metrics
   - Increase rate limits
   - Disable `synapse` `retention_policy`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository contains the documentation and configuration necessary to run a
 Raiden Service Bundle.
 
-**Current release:** [2020.11.1](https://github.com/raiden-network/raiden-service-bundle/tree/2020.11.1)
+**Current release:** [2020.11.2](https://github.com/raiden-network/raiden-service-bundle/tree/2020.11.2)
 
 ## Table of Contents
 
@@ -145,11 +145,11 @@ host an application that relies on either Cookies or LocalStorage for security r
 
 ### Installing the RSB
 
-1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2020.11.1)
+1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2020.11.2)
    to a suitable location on the server:
 
    ```shell
-   git clone -b 2020.11.1 https://github.com/raiden-network/raiden-service-bundle.git
+   git clone -b 2020.11.2 https://github.com/raiden-network/raiden-service-bundle.git
    ```
 1. Copy `.env.template` to `.env` and modify the values to fit your setup. Please read [Configuring the `.env` file](#configuring-the-env-file) for detailed information.
    - We would appreciate it if you allow us access to the monitoring interfaces

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,4 +1,14 @@
 # Upgrading existing installations
+## From `2020.11.1` or earlier
+
+The previous release mistakenly did not upgrade Synapse, so please make sure to reset the database with this upgrade:
+
+This can be done by stopping the entire RSB:
+
+    docker-compose stop
+
+And then removing the postgres data directory (`<DATA_DIR>/db`).
+
 ## From `2020.10.3` or earlier
 
 Due to the jump in Synapse version we recommend to wipe the Synapse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,17 @@ x-versions:
   services: &IMAGE_RAIDEN_SERVICES_VERSION
     image: raidennetwork/raiden-services:v0.13.2
   db: &IMAGE_DB_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.11.1-db
+    image: raidennetwork/raiden-service-bundle:2020.11.2-db
   synapse: &IMAGE_SYNAPSE_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.11.1-synapse
+    image: raidennetwork/raiden-service-bundle:2020.11.2-synapse
   well-known-server: &IMAGE_WELL_KNOWN_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.11.1-well_known_server
+    image: raidennetwork/raiden-service-bundle:2020.11.2-well_known_server
   room_ensurer: &IMAGE_ROOM_ENSURER_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.11.1-room_ensurer
+    image: raidennetwork/raiden-service-bundle:2020.11.2-room_ensurer
   purger: &IMAGE_PURGER_VERSION
-    image: raidennetwork/raiden-service-bundle:2020.11.1-purger
+    image: raidennetwork/raiden-service-bundle:2020.11.2-purger
   state_groups_cleaner: &IMAGE_STATE_GROUPS_CLEANER
-    image: raidennetwork/raiden-service-bundle:2020.11.1-state_groups_cleaner
+    image: raidennetwork/raiden-service-bundle:2020.11.2-state_groups_cleaner
   redis: &IMAGE_REDIS_VERSION
     image: redis:6.0
   metrics_db: &IMAGE_METRICS_DB_VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.3'
 # versions: change these in order to pin versions for a certain releases
 x-versions:
   services: &IMAGE_RAIDEN_SERVICES_VERSION
-    image: raidennetwork/raiden-services:v0.13.1
+    image: raidennetwork/raiden-services:v0.13.2
   db: &IMAGE_DB_VERSION
     image: raidennetwork/raiden-service-bundle:2020.11.1-db
   synapse: &IMAGE_SYNAPSE_VERSION


### PR DESCRIPTION
This new release fixes a mistake from `2020.11.1`. 
Also the newest `raiden-services` are included.

I will push the tag, once this gets merged.