### PR TITLE
Add raijin1.raiden.ninja to federation whitelist

### DIFF
--- a/known_servers/known_servers-production-v1.2.0.json
+++ b/known_servers/known_servers-production-v1.2.0.json
@@ -5,6 +5,7 @@
     ],
     "all_servers": [
         "transport.raiden.overdoze.se",
-        "transport.rsb.test.raiden.network"
+        "transport.rsb.test.raiden.network",
+        "transport.raijin1.raiden.ninja"
     ]
 }


### PR DESCRIPTION
The Matrix server seems to be running.
``` fish
 [I] ➜ http https://transport.raijin1.raiden.ninja/_matrix/client/versions
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization
Access-Control-Allow-Methods: GET, HEAD, POST, PUT, DELETE, OPTIONS
Access-Control-Allow-Origin: *
Cache-Control: no-cache, no-store, must-revalidate
Content-Length: 353
Content-Type: application/json
Date: Mon, 18 Jan 2021 15:34:08 GMT
Server: Synapse/1.22.1

{
    "unstable_features": {
        "io.element.e2ee_forced.private": false,
        "io.element.e2ee_forced.public": false,
        "io.element.e2ee_forced.trusted_private": false,
        "org.matrix.e2e_cross_signing": true,
        "org.matrix.label_based_filtering": true,
        "org.matrix.msc2432": true,
        "uk.half-shot.msc2666": true
    },
    "versions": [
        "r0.0.1",
        "r0.1.0",
        "r0.2.0",
        "r0.3.0",
        "r0.4.0",
        "r0.5.0",
        "r0.6.0"
    ]
}
```

The PFS does not seem to be functioning:

```fish
[I] ➜ http https://pfs.raijin1.raiden.ninja/api/v1/info/
HTTP/1.1 404 Not Found
Content-Length: 19
Content-Type: text/plain; charset=utf-8
Date: Mon, 18 Jan 2021 15:40:55 GMT
X-Content-Type-Options: nosniff

404 page not found
```