### PR TITLE
Remove device id regstration in auth provider

### DIFF
--- a/build/synapse/eth_auth_provider.py
+++ b/build/synapse/eth_auth_provider.py
@@ -113,8 +113,7 @@ class EthAuthProvider:
 
         if not (await self.account_handler.check_user_exists(user_id)):
             self.log.info("First login, creating new user: user=%r", user_id)
-            registered_user_id = await self.account_handler.register_user(localpart=localpart)
-            await self.account_handler.register_device(registered_user_id, device_id="raiden")
+            await self.account_handler.register_user(localpart=localpart)
 
         return True
 


### PR DESCRIPTION
The `ETHAuthProvider` does not need to register the device id to `raiden` as we log into the servers with `device_id` explicitly set. It will register automatically.