### PR TITLE
Add PFSPresenceRouter module to synapse

### DIFF
--- a/build/synapse/Dockerfile
+++ b/build/synapse/Dockerfile
@@ -6,19 +6,21 @@ RUN /opt/venv/bin/python -c \
     from raiden.constants import Environment; \
     print(DEFAULT_MATRIX_KNOWN_SERVERS[Environment.PRODUCTION])' > /known_servers.default.txt
 
-FROM python:3.7
+FROM python:3.8
 LABEL maintainer="Raiden Network Team <contact@raiden.network>"
 
 ARG SYNAPSE_VERSION
 
 RUN \
     python -m venv /synapse-venv && \
-    /synapse-venv/bin/pip install "matrix-synapse[postgres,redis]==${SYNAPSE_VERSION}"
+    /synapse-venv/bin/pip install "git+https://github.com/matrix-org/synapse.git@anoa/presence_hook#egg=matrix-synapse[postgres,redis]"
 
 RUN /synapse-venv/bin/pip install psycopg2 coincurve pycryptodome "twisted>=20.3.0" click==7.1.2 docker-py
 
-COPY eth_auth_provider.py /synapse-venv/lib/python3.7/site-packages/
-COPY admin_user_auth_provider.py /synapse-venv/lib/python3.7/site-packages/
+RUN /synapse-venv/bin/pip install git+https://github.com/raiden-network/raiden-synapse-modules.git@main
+
+COPY eth_auth_provider.py /synapse-venv/lib/python3.8/site-packages/
+COPY admin_user_auth_provider.py /synapse-venv/lib/python3.8/site-packages/
 COPY synapse-entrypoint.sh /bin/
 COPY render_config_template.py /bin/
 COPY --from=RAIDEN /known_servers.default.txt /

--- a/config/synapse/synapse.log.config
+++ b/config/synapse/synapse.log.config
@@ -24,6 +24,8 @@ handlers:
     filters: [context]
 
 loggers:
+    raiden_synapse_modules:
+        level: DEBUG
     synapse:
         level: WARNING
     synapse.access.http:

--- a/config/synapse/synapse.template.yaml
+++ b/config/synapse/synapse.template.yaml
@@ -194,3 +194,12 @@ database:
     host: db
     cp_min: 5
     cp_max: 20
+
+presence:
+    enabled: true
+    presence_router:
+      module: raiden_synapse_modules.pfs_presence_router.PFSPresenceRouter
+      config:
+        ethereum_rpc: ${ETH_RPC}
+        service_registry_address: 0x3bc9C8d34f5714327095358668fD436D7c457C6C
+        blockchain_sync_seconds: 15


### PR DESCRIPTION
This adds https://github.com/raiden-network/raiden-synapse-modules to the synapse container. 

**Note**: it installs synapse from the WIP branch for https://github.com/matrix-org/synapse/pull/9491 -- if that PR lands in a release before you can/want to merge this, then

https://github.com/raiden-network/raiden-service-bundle/pull/262/files#diff-1da865ee745cd0ef9821b9c1e7d07c37046a17be251e7efe52f70a585129f7cbL16-R16

can be changed back to the original.

### Changes in detail
- upgrade synapse container to `python3.8` (`raiden_synapse_modules` needs it)
- install `raiden_synapse_modules` in container
- install `synapse` from synapse-PR-9491
- add configuration template for presence router (so far with a [hardcoded service registry address](https://github.com/raiden-network/raiden-synapse-modules/issues/8) for current `goerli` deployment)
- add `raiden_synapse_modules` to synapse log configuration

This fixes #260 