### PR TITLE
Local testing of PFSPresenceRouter

### DIFF
--- a/build/synapse/Dockerfile
+++ b/build/synapse/Dockerfile
@@ -6,19 +6,21 @@ RUN /opt/venv/bin/python -c \
     from raiden.constants import Environment; \
     print(DEFAULT_MATRIX_KNOWN_SERVERS[Environment.PRODUCTION])' > /known_servers.default.txt
 
-FROM python:3.7
+FROM python:3.8
 LABEL maintainer="Raiden Network Team <contact@raiden.network>"
 
 ARG SYNAPSE_VERSION
 
 RUN \
     python -m venv /synapse-venv && \
-    /synapse-venv/bin/pip install "matrix-synapse[postgres,redis]==${SYNAPSE_VERSION}"
+    /synapse-venv/bin/pip install "git+https://github.com/matrix-org/synapse.git@anoa/presence_hook#egg=matrix-synapse[postgres,redis]"
 
 RUN /synapse-venv/bin/pip install psycopg2 coincurve pycryptodome "twisted>=20.3.0" click==7.1.2 docker-py
 
-COPY eth_auth_provider.py /synapse-venv/lib/python3.7/site-packages/
-COPY admin_user_auth_provider.py /synapse-venv/lib/python3.7/site-packages/
+RUN /synapse-venv/bin/pip install git+https://github.com/raiden-network/raiden-synapse-modules.git@main
+
+COPY eth_auth_provider.py /synapse-venv/lib/python3.8/site-packages/
+COPY admin_user_auth_provider.py /synapse-venv/lib/python3.8/site-packages/
 COPY synapse-entrypoint.sh /bin/
 COPY render_config_template.py /bin/
 COPY --from=RAIDEN /known_servers.default.txt /

--- a/config/synapse/synapse.log.config
+++ b/config/synapse/synapse.log.config
@@ -2,12 +2,8 @@ version: 1
 
 formatters:
   precise:
-   format: '%(asctime)s %(name)s(%(lineno)d) [%(levelname)-8s]: %(request)s %(message)s'
+   format: '%(asctime)s %(name)s(%(lineno)d) [%(levelname)-8s]:  %(message)s'
 
-filters:
-  context:
-    (): synapse.util.logcontext.LoggingContextFilter
-    request: ""
 
 handlers:
   file:
@@ -16,28 +12,22 @@ handlers:
     filename: /data/log/synapse.log
     maxBytes: 104857600
     backupCount: 50
-    filters: [context]
   console:
     class: logging.StreamHandler
     level: DEBUG
     formatter: precise
-    filters: [context]
 
 loggers:
     raiden_synapse_modules:
         level: DEBUG
     synapse:
-        level: WARNING
-    synapse.access.http:
-        level: INFO
-    synapse.rest.client.v2_alpha.sync:
-        level: INFO
+        level: DEBUG
     synapse.storage.SQL:
         # beware: increasing this to DEBUG will make synapse log sensitive
         # information such as access tokens.
         level: WARNING
 
 root:
-    level: WARNING
+    level: DEBUG
     handlers: [file, console]
 

--- a/config/synapse/synapse.log.config
+++ b/config/synapse/synapse.log.config
@@ -24,6 +24,8 @@ handlers:
     filters: [context]
 
 loggers:
+    raiden_synapse_modules:
+        level: DEBUG
     synapse:
         level: WARNING
     synapse.access.http:

--- a/config/synapse/synapse.template.yaml
+++ b/config/synapse/synapse.template.yaml
@@ -33,7 +33,7 @@ listeners:
       - names: [replication]
 
 redis:
-  enabled: true
+  enabled: false
   host: redis
 
 event_cache_size: "20K"
@@ -184,22 +184,16 @@ enable_group_creation: false
 
 user_directory:
   search_all_users: true
-
 database:
-  name: psycopg2
+  name: sqlite3
   args:
-    user: postgres
-    password:
-    database: synapse
-    host: db
-    cp_min: 5
-    cp_max: 20
+    database: ":memory:"
 
 presence:
     enabled: true
     presence_router:
       module: raiden_synapse_modules.pfs_presence_router.PFSPresenceRouter
       config:
-        ethereum_rpc: ${ETH_RPC}
+        ethereum_rpc: https://goerli.infura.io/v3/FILLMEIN
         service_registry_address: 0x3bc9C8d34f5714327095358668fD436D7c457C6C
         blockchain_sync_seconds: 15

--- a/config/synapse/synapse.template.yaml
+++ b/config/synapse/synapse.template.yaml
@@ -194,3 +194,12 @@ database:
     host: db
     cp_min: 5
     cp_max: 20
+
+presence:
+    enabled: true
+    presence_router:
+      module: raiden_synapse_modules.pfs_presence_router.PFSPresenceRouter
+      config:
+        ethereum_rpc: ${ETH_RPC}
+        service_registry_address: 0x3bc9C8d34f5714327095358668fD436D7c457C6C
+        blockchain_sync_seconds: 15


### PR DESCRIPTION
This contains some configuration changes, that should make it easy to run and debug a synapse instance locally.

#### build container
   
    docker build --no-cache --build-arg "RAIDEN_VERSION=develop" -t test_synapse build/synapse
   
#### run instance    
 
    docker run -e SERVER_NAME=foobar --name synapse_test -it -v $(pwd)/data/synapse:/data -v $(pwd)/data/well_known:/data_well_known -v $(pwd)/config/synapse:/config test_synapse

