### PR TITLE
Remove CI build rule for compress_state image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
       build-target:
         description: "Which component are we building"
         type: enum
-        enum: ["synapse", "db", "well_known_server", "purger", "rust_synapse_compress_state"]
+        enum: ["synapse", "db", "well_known_server", "purger"]
     steps:
       - checkout
       - setup_remote_docker:
@@ -69,12 +69,6 @@ jobs:
       - build-container:
           build-target: purger
 
-  build_rust_synapse_compress_state:
-    executor: default
-    steps:
-      - build-container:
-          build-target: rust_synapse_compress_state
-
 
 workflows:
   version: 2
@@ -84,7 +78,6 @@ workflows:
       - build_db
       - build_well_known
       - build_purger
-      - build_rust_synapse_compress_state
 
   tagged_images:
     jobs:
@@ -107,12 +100,6 @@ workflows:
             branches:
               ignore: /.*/
       - build_purger:
-          filters:
-            tags:
-              only: /.+/
-            branches:
-              ignore: /.*/
-      - build_rust_synapse_compress_state:
           filters:
             tags:
               only: /.+/


### PR DESCRIPTION
#277 removed the compress_state service.
This also removes the now stale CI build instructions for it.