### PR TITLE
Add runtime reloading of the federation whitelist

### DIFF
--- a/build/synapse/Dockerfile
+++ b/build/synapse/Dockerfile
@@ -30,6 +30,7 @@ RUN sed -i 's/\(\s*\)if self.worker_type/\1if True or self.worker_type/' /synaps
 
 COPY eth_auth_provider.py /synapse-venv/lib/python3.9/site-packages/
 COPY admin_user_auth_provider.py /synapse-venv/lib/python3.9/site-packages/
+COPY federation_whitelist_reloader.py /synapse-venv/lib/python3.9/site-packages/
 COPY synapse-entrypoint.sh /bin/
 COPY render_config_template.py /bin/
 COPY --from=RAIDEN /known_servers.default.txt /

--- a/build/synapse/federation_whitelist_reloader.py
+++ b/build/synapse/federation_whitelist_reloader.py
@@ -1,0 +1,61 @@
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from synapse.api.errors import HttpResponseException
+from synapse.handlers.auth import AuthHandler
+
+
+# This file gets created during docker build from the given Raiden version
+from synapse.http import RequestTimedOutError
+from synapse.metrics.background_process_metrics import run_as_background_process
+
+
+PATH_KNOWN_FEDERATION_SERVERS_DEFAULT_URL = Path("/known_servers.default.txt")
+
+
+class FederationWhitelistReloaderProvider:
+    """
+    Helper that peridoically fetches and updates the allowed federation domain whitelist.
+
+    Implemented as a password provider since this is a handy way to inject code into Synapse.
+    """
+
+    __version__ = "0.1"
+
+    def __init__(self, config: Dict[str, Any], account_handler: AuthHandler) -> None:
+        self.hs = account_handler._hs
+        self.known_servers_url = os.environ.get(
+            "URL_KNOWN_FEDERATION_SERVERS", PATH_KNOWN_FEDERATION_SERVERS_DEFAULT_URL.read_text()
+        )
+        self.update_interval = config.get("update_interval", 3600)
+        self.log = logging.getLogger(__name__)
+        self.clock = self.hs.get_clock()
+        self.clock.call_later(0, self.run_check_and_fetch_in_background)
+
+    @staticmethod
+    def parse_config(config: Dict[str, Any]) -> Dict[str, Any]:
+        return config
+
+    def run_check_and_fetch_in_background(self) -> None:
+        run_as_background_process(
+            "federation_whitelist_reloader", self._check_and_update_whitelist
+        )
+
+    async def _check_and_update_whitelist(self) -> None:
+        http_client = self.hs.get_proxied_blacklisted_http_client()
+        try:
+            known_servers = await http_client.get_json(self.known_servers_url)
+            if not isinstance(known_servers, dict):
+                raise TypeError(f"Invalid response format from known servers URL: {known_servers}")
+            if "all_servers" not in known_servers:
+                raise ValueError(
+                    f"Known servers response is missing 'all_serves' key: {known_servers}"
+                )
+            new_whitelist = known_servers["all_servers"]
+            self.hs.config.federation_domain_whitelist = {domain: True for domain in new_whitelist}
+            self.log.warning("Updated federation whitelist. New list: %s", new_whitelist)
+        except (HttpResponseException, RequestTimedOutError, TypeError, ValueError) as ex:
+            self.log.error(f"Error fetching federation known servers: {ex}. Will retry later.")
+        self.clock.call_later(self.update_interval, self.run_check_and_fetch_in_background)

--- a/config/synapse/synapse.template.yaml
+++ b/config/synapse/synapse.template.yaml
@@ -117,6 +117,9 @@ password_providers:
     config:
       enabled: true
       credentials_file: /config/admin_user_cred.json
+  - module: 'federation_whitelist_reloader.FederationWhitelistReloaderProvider'
+    config:
+      enabled: true
 
 bcrypt_rounds: 12
 


### PR DESCRIPTION
Previously the 'purger' service would periodically check if the configured whitelist of known federation servers was still up to date and if not restart the affected synapse services.

That caused downtime and also was a somewhat annoying workaround.

This now introduces a module that checks and updates the configuration at runtime without the need for a restart.

Note that this is accessing Synapse internals that aren't considered stable and therefore subject to change with future version upgrades.