### PR TITLE
fix Synapse configuration file format

### DIFF
--- a/config/synapse/synapse.template.yaml
+++ b/config/synapse/synapse.template.yaml
@@ -132,7 +132,7 @@ presence:
     module: raiden_synapse_modules.presence_router.pfs.PFSPresenceRouter
     config:
       ethereum_rpc: ${ETH_RPC}
-      service_registry_address: ${SERVICE_REGISTRY}
+      service_registry_address: "${SERVICE_REGISTRY}"
       blockchain_sync_seconds: 15
 
 ## Metrics ###


### PR DESCRIPTION
For unknown reasons the Synapse module by Raiden for the presence started to throw issues on parsing the configuration file. The `service_registry_address` option in the module configuration gets parsed as an integer. In the following the `eth_utils` functions fail to parse this number as a valid Ethereum address. In result the whole server fails to start.

The exact origin of this new problem is not known. Maybe the parsing of hex values in a YAML file get now specially parsed and not taken are pure strings anymore. In any case a simple solution is to explicitly make the value a string by putting quotation marks around it in the configuration template file. This change is not invasive and is also backwards compatible.