### PR TITLE
Chore/release 2022 05 0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
-current_version = 2021.12.0
+current_version = 2022.05.0
 commit = True
 tag = True
 tag_name = {new_version}
 parse = (?P<year>\d+)\.(?P<month>\d+)\.(?P<release>\d+)(?:rc(?P<rc>\d+))?
-serialize =
+serialize = 
 	{year}.{month}.{release}rc{rc}
 	{year}.{month}.{release}
 
@@ -13,7 +13,7 @@ serialize =
 [bumpversion:file:docker-compose.yml]
 
 [bumpversion:part:month]
-values =
+values = 
 	01
 	02
 	03

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
       build-target:
         description: "Which component are we building"
         type: enum
-        enum: ["synapse", "db", "well_known_server", "purger"]
+        enum: ["synapse", "db", "well_known_server"]
     steps:
       - checkout
       - setup_remote_docker:
@@ -63,13 +63,6 @@ jobs:
       - build-container:
           build-target: well_known_server
 
-  build_purger:
-    executor: default
-    steps:
-      - build-container:
-          build-target: purger
-
-
 workflows:
   version: 2
   build_images:
@@ -77,7 +70,6 @@ workflows:
       - build_synapse
       - build_db
       - build_well_known
-      - build_purger
 
   tagged_images:
     jobs:
@@ -94,12 +86,6 @@ workflows:
             branches:
               ignore: /.*/
       - build_well_known:
-          filters:
-            tags:
-              only: /.+/
-            branches:
-              ignore: /.*/
-      - build_purger:
           filters:
             tags:
               only: /.+/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Changelog
+- 2022-05-02 - `2022.05.0` - **Upgrade Release**
+  - Updated `raiden-services` to `v2.0.0`
+  - Updated `raiden-synapse-modules` to `0.1.4`
+  - Removed `raiden` dependency for synapse image
+  - Fix synapse configuration file format
 - 2021-12-06 - `2021.12.0` - **Release Candidate**
   - Upgrade to Raiden 3.0.0rc8
 - 2021-07-01 - `2021.07.0rc0` - **Release Candidate**

--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ can identify this, if there is an `rcX` at the end of the version (E.g. `2019.03
 [latest full release](https://github.com/raiden-network/raiden-service-bundle/releases/latest). If the version is
 different from what you see below, you should stick to the "full release" and replace the version accordingly.
 
-1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2021.12.0)
+1. Clone the [current release version of this repository](https://github.com/raiden-network/raiden-service-bundle/tree/2022.05.0)
    to a suitable location on the server:
 
    ```shell
-   git clone -b 2021.12.0 https://github.com/raiden-network/raiden-service-bundle.git
+   git clone -b 2022.05.0 https://github.com/raiden-network/raiden-service-bundle.git
    ```
 1. Copy `.env.template` to `.env` and modify the values to fit your setup. Please read [Configuring the `.env` file](#configuring-the-env-file) for detailed information.
    - We would appreciate it if you allow us access to the monitoring interfaces

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ x-versions:
   services: &IMAGE_RAIDEN_SERVICES_VERSION
     image: raidennetwork/raiden-services:v2.0.0
   db: &IMAGE_DB_VERSION
-    image: raidennetwork/raiden-service-bundle:2021.12.0-db
+    image: raidennetwork/raiden-service-bundle:2022.05.0-db
   synapse: &IMAGE_SYNAPSE_VERSION
-    image: raidennetwork/raiden-service-bundle:2021.12.0-synapse
+    image: raidennetwork/raiden-service-bundle:2022.05.0-synapse
   well-known-server: &IMAGE_WELL_KNOWN_VERSION
-    image: raidennetwork/raiden-service-bundle:2021.12.0-well_known_server
+    image: raidennetwork/raiden-service-bundle:2022.05.0-well_known_server
   redis: &IMAGE_REDIS_VERSION
     image: redis:6.0
   metrics_db: &IMAGE_METRICS_DB_VERSION


### PR DESCRIPTION
This is my first `raiden-service-bundle` release. I followed the [docs](https://github.com/raiden-network/team/wiki/Making-releases#raiden-service-bundle).

Here is the prepared message for the GitHub release (tag):

## 2022.05.0 - Release notes

_Please check UPGRADING.md!_

This is an upgrade release.

All components of the RSB have been updated to their latest versions.

There are no user-visible functionality changes.
As always please refer to the upgrading documentation when applying this update.

### Changes included
  - Updated `raiden-services` to `v2.0.0`
  - Updated `raiden-synapse-modules` to `0.1.4`
  - Removed `raiden` dependency for synapse image
  - Fix synapse configuration file format
